### PR TITLE
Add comprehensive scaffolding functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "initrepo",
   "version": "1.0.0",
-  "description": "A CLI tool to extract and analyze codebase context for AI consumption",
+  "description": "A CLI tool to extract and analyze codebase context for AI consumption and scaffold new projects",
   "type": "module",
   "main": "src/main.js",
   "bin": {
@@ -18,7 +18,12 @@
     "analysis",
     "ai",
     "documentation",
-    "extraction"
+    "extraction",
+    "scaffolding",
+    "nextjs",
+    "react",
+    "python",
+    "automation"
   ],
   "author": "InitRepo Team",
   "license": "MIT",

--- a/src/commands/scaffold.js
+++ b/src/commands/scaffold.js
@@ -1,0 +1,173 @@
+/**
+ * Scaffold Command Handler
+ * 
+ * This module handles the scaffold command for creating organized project structures.
+ * It supports reading from technical_architecture.md files or using predefined templates.
+ */
+
+import { existsSync, mkdirSync } from 'fs';
+import { join, resolve } from 'path';
+import colors from 'picocolors';
+import { Command } from 'commander';
+
+import { parseArchitectureFile } from '../parsers/architecture-parser.js';
+import { NextJSScaffolder } from '../scaffolders/nextjs-scaffolder.js';
+import { ReactScaffolder } from '../scaffolders/react-scaffolder.js';
+import { ReactNativeScaffolder } from '../scaffolders/react-native-scaffolder.js';
+import { PythonMCPScaffolder } from '../scaffolders/python-mcp-scaffolder.js';
+import { PythonAutomationScaffolder } from '../scaffolders/python-automation-scaffolder.js';
+
+/**
+ * Supported project types and their corresponding scaffolders
+ */
+const SCAFFOLDERS = {
+  'nextjs': NextJSScaffolder,
+  'react': ReactScaffolder,
+  'react-native': ReactNativeScaffolder,
+  'python-mcp': PythonMCPScaffolder,
+  'python-automation': PythonAutomationScaffolder
+};
+
+/**
+ * Configures the scaffold command for the CLI
+ * 
+ * @param {Command} program - Commander.js program instance
+ */
+export function configureScaffoldCommand(program) {
+  program
+    .command('scaffold')
+    .description('Create a new project with organized structure')
+    .argument('<type>', `Project type: ${Object.keys(SCAFFOLDERS).join(', ')}`)
+    .argument('<name>', 'Project name')
+    .option('-a, --architecture <file>', 'Path to technical_architecture.md file')
+    .option('-d, --directory <dir>', 'Target directory (defaults to project name)')
+    .option('--no-install', 'Skip dependency installation')
+    .option('--no-git', 'Skip git initialization')
+    .option('-t, --template <template>', 'Use specific template variant')
+    .action(async (type, name, options) => {
+      try {
+        await handleScaffoldCommand(type, name, options);
+      } catch (error) {
+        console.error(colors.red('Scaffold Error:'), error.message);
+        process.exit(1);
+      }
+    });
+}
+
+/**
+ * Handles the scaffold command execution
+ * 
+ * @param {string} type - Project type
+ * @param {string} name - Project name
+ * @param {Object} options - Command options
+ */
+export async function handleScaffoldCommand(type, name, options) {
+  const startTime = Date.now();
+  
+  // Validate project type
+  if (!SCAFFOLDERS[type]) {
+    throw new Error(`Unsupported project type: ${type}. Supported types: ${Object.keys(SCAFFOLDERS).join(', ')}`);
+  }
+  
+  // Determine target directory
+  const targetDir = options.directory ? resolve(options.directory) : resolve(name);
+  
+  console.log(colors.blue('🏗️  InitRepo Scaffolder'));
+  console.log(colors.dim(`Creating ${type} project: ${colors.bold(name)}`));
+  console.log(colors.dim(`Target directory: ${targetDir}`));
+  console.log();
+  
+  // Check if target directory exists
+  if (existsSync(targetDir)) {
+    throw new Error(`Directory already exists: ${targetDir}`);
+  }
+  
+  // Create target directory
+  mkdirSync(targetDir, { recursive: true });
+  console.log(colors.green('✓'), 'Created project directory');
+  
+  // Check for architecture file
+  let architectureData = null;
+  const archFile = options.architecture || 'technical_architecture.md';
+  const archPath = resolve(archFile);
+  
+  if (existsSync(archPath)) {
+    console.log(colors.cyan('📋 Reading architecture file...'));
+    try {
+      architectureData = await parseArchitectureFile(archPath);
+      console.log(colors.green('✓'), 'Parsed architecture file successfully');
+    } catch (error) {
+      console.warn(colors.yellow('⚠️'), `Could not parse architecture file: ${error.message}`);
+      console.log(colors.dim('   Using default template instead'));
+    }
+  }
+  
+  // Initialize scaffolder
+  const ScaffolderClass = SCAFFOLDERS[type];
+  const scaffolder = new ScaffolderClass({
+    projectName: name,
+    targetDirectory: targetDir,
+    architecture: architectureData,
+    template: options.template,
+    installDeps: options.install !== false,
+    initGit: options.git !== false
+  });
+  
+  // Execute scaffolding
+  console.log(colors.cyan('🔨 Scaffolding project structure...'));
+  await scaffolder.scaffold();
+  console.log(colors.green('✓'), 'Project structure created');
+  
+  // Install dependencies if requested
+  if (options.install !== false && scaffolder.supportsDependencyInstallation()) {
+    console.log(colors.cyan('📦 Installing dependencies...'));
+    await scaffolder.installDependencies();
+    console.log(colors.green('✓'), 'Dependencies installed');
+  }
+  
+  // Initialize git if requested
+  if (options.git !== false) {
+    console.log(colors.cyan('🔧 Initializing git repository...'));
+    await scaffolder.initializeGit();
+    console.log(colors.green('✓'), 'Git repository initialized');
+  }
+  
+  const duration = Date.now() - startTime;
+  console.log();
+  console.log(colors.green('🎉 Project scaffolded successfully!'));
+  console.log(colors.dim(`Total time: ${duration}ms`));
+  console.log();
+  console.log('Next steps:');
+  console.log(colors.dim(`  cd ${name}`));
+  
+  // Show type-specific next steps
+  const nextSteps = scaffolder.getNextSteps();
+  nextSteps.forEach(step => {
+    console.log(colors.dim(`  ${step}`));
+  });
+}
+
+/**
+ * Validates project name
+ * 
+ * @param {string} name - Project name to validate
+ * @returns {boolean} True if valid
+ */
+export function validateProjectName(name) {
+  const validNameRegex = /^[a-zA-Z0-9-_]+$/;
+  return validNameRegex.test(name) && name.length > 0 && name.length <= 50;
+}
+
+/**
+ * Sanitizes project name for use in file paths and package names
+ * 
+ * @param {string} name - Raw project name
+ * @returns {string} Sanitized name
+ */
+export function sanitizeProjectName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9-_]/g, '-')
+    .replace(/--+/g, '-')
+    .replace(/^-|-$/g, '');
+}

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import { getRelevantFiles, readFiles } from './file-handler.js';
 import { generateTechStack } from './generators/generate-tech-stack.js';
 import { generateProjectStructure } from './generators/generate-project-structure.js';
 import { generateFullCodebase } from './generators/generate-full-codebase.js';
+import { configureScaffoldCommand } from './commands/scaffold.js';
 
 // Get current directory for ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -30,7 +31,7 @@ export async function main() {
   // Configure the main command
   program
     .name('initrepo')
-    .description('Extract and analyze codebase context for AI consumption')
+    .description('Extract and analyze codebase context for AI consumption, and scaffold new projects')
     .version('1.0.0')
     .option('--init', 'Create a default .initrepoignore file in the current directory')
     .action(async (options) => {
@@ -45,6 +46,9 @@ export async function main() {
         process.exit(1);
       }
     });
+
+  // Configure scaffold command
+  configureScaffoldCommand(program);
 
   // Parse command line arguments
   program.parse();

--- a/src/parsers/architecture-parser.js
+++ b/src/parsers/architecture-parser.js
@@ -1,0 +1,331 @@
+/**
+ * Architecture Parser
+ * 
+ * This module parses technical_architecture.md files to extract project structure
+ * and configuration information for scaffolding projects.
+ */
+
+import { readFileSync } from 'fs';
+import { basename } from 'path';
+
+/**
+ * Parses a technical architecture markdown file
+ * 
+ * @param {string} filePath - Path to the technical_architecture.md file
+ * @returns {Promise<Object>} Parsed architecture data
+ */
+export async function parseArchitectureFile(filePath) {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    
+    const architecture = {
+      projectName: extractProjectName(content, filePath),
+      projectType: detectProjectType(content),
+      structure: parseDirectoryStructure(content),
+      dependencies: extractDependencies(content),
+      features: extractFeatures(content),
+      configuration: extractConfiguration(content),
+      metadata: {
+        sourceFile: filePath,
+        parsedAt: new Date().toISOString()
+      }
+    };
+    
+    return architecture;
+  } catch (error) {
+    throw new Error(`Failed to parse architecture file: ${error.message}`);
+  }
+}
+
+/**
+ * Extracts project name from the content or filename
+ * 
+ * @param {string} content - File content
+ * @param {string} filePath - File path
+ * @returns {string} Project name
+ */
+function extractProjectName(content, filePath) {
+  // Look for project name in various formats
+  const patterns = [
+    /^#\s+(.+)$/m,                          // Main heading
+    /project[:\s]+(.+)$/im,                 // "Project: Name"
+    /name[:\s]+(.+)$/im,                    // "Name: Project"
+    /^##?\s*(.+?)\s*(?:project|app)/im      // "Name Project" or "Name App"
+  ];
+  
+  for (const pattern of patterns) {
+    const match = content.match(pattern);
+    if (match) {
+      return match[1].trim().replace(/[^\w\s-]/g, '');
+    }
+  }
+  
+  // Fallback to directory structure if found
+  const structureMatch = content.match(/^(.+?)\//m);
+  if (structureMatch) {
+    return structureMatch[1].trim();
+  }
+  
+  // Final fallback to filename
+  return basename(filePath, '.md').replace(/[_-]/g, ' ');
+}
+
+/**
+ * Detects the project type based on content analysis
+ * 
+ * @param {string} content - File content
+ * @returns {string} Detected project type
+ */
+function detectProjectType(content) {
+  const lowerContent = content.toLowerCase();
+  
+  // Check for specific technologies and patterns
+  const typeIndicators = {
+    'nextjs': [
+      'next.js', 'nextjs', 'app/', 'next.config.js', 
+      'app router', 'pages/', '_app.tsx', 'layout.tsx'
+    ],
+    'react': [
+      'react', 'create-react-app', 'src/components', 
+      'jsx', 'tsx', 'react-dom'
+    ],
+    'react-native': [
+      'react native', 'react-native', 'expo', 'metro',
+      'ios/', 'android/', 'app.tsx', 'app.js'
+    ],
+    'python-mcp': [
+      'mcp', 'model context protocol', 'server.py',
+      'tools/', 'handlers/', '__init__.py'
+    ],
+    'python-automation': [
+      'automation', 'script', 'tasks/', 'workflows/',
+      'main.py', 'requirements.txt', 'config/'
+    ]
+  };
+  
+  let maxScore = 0;
+  let detectedType = 'nextjs'; // default
+  
+  for (const [type, indicators] of Object.entries(typeIndicators)) {
+    let score = 0;
+    for (const indicator of indicators) {
+      if (lowerContent.includes(indicator)) {
+        score += 1;
+      }
+    }
+    
+    if (score > maxScore) {
+      maxScore = score;
+      detectedType = type;
+    }
+  }
+  
+  return detectedType;
+}
+
+/**
+ * Parses directory structure from code blocks or tree representations
+ * 
+ * @param {string} content - File content
+ * @returns {Object} Parsed directory structure
+ */
+function parseDirectoryStructure(content) {
+  // Look for code blocks or tree structures
+  const codeBlockRegex = /```[\s\S]*?```/g;
+  const codeBlocks = content.match(codeBlockRegex) || [];
+  
+  const structure = {
+    directories: [],
+    files: [],
+    tree: null
+  };
+  
+  for (const block of codeBlocks) {
+    const blockContent = block.replace(/```[\w]*\n?/, '').replace(/```$/, '');
+    
+    // Check if this looks like a directory structure
+    if (isDirectoryStructure(blockContent)) {
+      const parsed = parseTreeStructure(blockContent);
+      if (parsed.directories.length > 0 || parsed.files.length > 0) {
+        structure.directories.push(...parsed.directories);
+        structure.files.push(...parsed.files);
+        if (!structure.tree) {
+          structure.tree = blockContent;
+        }
+      }
+    }
+  }
+  
+  return structure;
+}
+
+/**
+ * Determines if content represents a directory structure
+ * 
+ * @param {string} content - Content to check
+ * @returns {boolean} True if it looks like a directory structure
+ */
+function isDirectoryStructure(content) {
+  const indicators = [
+    /├──/,           // Tree characters
+    /└──/,
+    /│/,
+    /\/$/m,          // Directories ending with /
+    /\.(js|ts|tsx|jsx|py|md|json|txt)$/m,  // File extensions
+    /^[\s]*[\w-]+\/[\s]*$/m  // Directory patterns
+  ];
+  
+  return indicators.some(pattern => pattern.test(content));
+}
+
+/**
+ * Parses a tree structure into directories and files
+ * 
+ * @param {string} treeContent - Tree structure content
+ * @returns {Object} Parsed structure with directories and files
+ */
+function parseTreeStructure(treeContent) {
+  const lines = treeContent.split('\n').filter(line => line.trim());
+  const directories = [];
+  const files = [];
+  
+  for (const line of lines) {
+    // Remove tree characters and whitespace
+    const cleaned = line
+      .replace(/[├└│]/g, '')
+      .replace(/──/g, '')
+      .replace(/^\s+/, '')
+      .trim();
+    
+    if (!cleaned) continue;
+    
+    // Check if it's a directory (ends with /) or has directory indicators
+    if (cleaned.endsWith('/') || cleaned.includes('//')) {
+      const dirPath = cleaned.replace(/\/$/, '').replace(/\s*\/\/.*$/, '');
+      if (dirPath && !directories.includes(dirPath)) {
+        directories.push(dirPath);
+      }
+    } else if (cleaned.includes('.')) {
+      // It's likely a file
+      const filePath = cleaned.replace(/\s*\/\/.*$/, '');
+      if (filePath && !files.includes(filePath)) {
+        files.push(filePath);
+      }
+    }
+  }
+  
+  return { directories, files };
+}
+
+/**
+ * Extracts dependencies from the content
+ * 
+ * @param {string} content - File content
+ * @returns {Object} Dependencies object
+ */
+function extractDependencies(content) {
+  const dependencies = {
+    npm: [],
+    python: [],
+    system: []
+  };
+  
+  // Look for package names and dependencies
+  const npmPackageRegex = /@[\w-]+\/[\w-]+|[\w-]+(?=\s*[:\s]*\d+\.\d+|\s*npm|\s*yarn)/gi;
+  const pythonPackageRegex = /(?:pip install|import|from)\s+([\w-]+)/gi;
+  
+  const npmMatches = content.match(npmPackageRegex) || [];
+  const pythonMatches = content.match(pythonPackageRegex) || [];
+  
+  dependencies.npm = [...new Set(npmMatches)];
+  dependencies.python = [...new Set(pythonMatches.map(m => m.split(' ').pop()))];
+  
+  return dependencies;
+}
+
+/**
+ * Extracts features and components from the content
+ * 
+ * @param {string} content - File content
+ * @returns {Array} Array of features
+ */
+function extractFeatures(content) {
+  const features = [];
+  
+  // Look for feature descriptions in headers and lists
+  const featurePatterns = [
+    /##\s*(.+?)(?=\n|$)/g,      // H2 headers
+    /###\s*(.+?)(?=\n|$)/g,     // H3 headers
+    /[-*]\s*(.+?)(?=\n|$)/g     // List items
+  ];
+  
+  for (const pattern of featurePatterns) {
+    const matches = [...content.matchAll(pattern)];
+    for (const match of matches) {
+      const feature = match[1].trim();
+      if (feature.length > 3 && feature.length < 100) {
+        features.push(feature);
+      }
+    }
+  }
+  
+  return [...new Set(features)];
+}
+
+/**
+ * Extracts configuration information
+ * 
+ * @param {string} content - File content
+ * @returns {Object} Configuration object
+ */
+function extractConfiguration(content) {
+  const config = {
+    typescript: content.toLowerCase().includes('typescript') || content.includes('.ts'),
+    tailwind: content.toLowerCase().includes('tailwind'),
+    eslint: content.toLowerCase().includes('eslint'),
+    prettier: content.toLowerCase().includes('prettier'),
+    testing: content.toLowerCase().includes('test') || content.toLowerCase().includes('jest'),
+    database: extractDatabaseInfo(content),
+    authentication: extractAuthInfo(content)
+  };
+  
+  return config;
+}
+
+/**
+ * Extracts database information from content
+ * 
+ * @param {string} content - File content
+ * @returns {string|null} Database type or null
+ */
+function extractDatabaseInfo(content) {
+  const dbTypes = ['postgresql', 'mysql', 'sqlite', 'mongodb', 'redis', 'prisma', 'supabase'];
+  const lowerContent = content.toLowerCase();
+  
+  for (const dbType of dbTypes) {
+    if (lowerContent.includes(dbType)) {
+      return dbType;
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Extracts authentication information from content
+ * 
+ * @param {string} content - File content
+ * @returns {string|null} Auth type or null
+ */
+function extractAuthInfo(content) {
+  const authTypes = ['clerk', 'auth0', 'firebase', 'nextauth', 'supabase auth'];
+  const lowerContent = content.toLowerCase();
+  
+  for (const authType of authTypes) {
+    if (lowerContent.includes(authType)) {
+      return authType;
+    }
+  }
+  
+  return null;
+}

--- a/src/scaffolders/base-scaffolder.js
+++ b/src/scaffolders/base-scaffolder.js
@@ -1,0 +1,226 @@
+/**
+ * Base Scaffolder
+ * 
+ * Abstract base class for all project scaffolders.
+ * Provides common functionality and interface definition.
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { execSync } from 'child_process';
+import colors from 'picocolors';
+
+export class BaseScaffolder {
+  constructor(options) {
+    this.projectName = options.projectName;
+    this.targetDirectory = options.targetDirectory;
+    this.architecture = options.architecture;
+    this.template = options.template;
+    this.installDeps = options.installDeps !== false;
+    this.initGit = options.initGit !== false;
+  }
+
+  /**
+   * Main scaffolding method - must be implemented by subclasses
+   */
+  async scaffold() {
+    throw new Error('scaffold() method must be implemented by subclass');
+  }
+
+  /**
+   * Get next steps for the user - should be overridden by subclasses
+   */
+  getNextSteps() {
+    return [
+      'npm install',
+      'npm run dev'
+    ];
+  }
+
+  /**
+   * Check if this scaffolder supports dependency installation
+   */
+  supportsDependencyInstallation() {
+    return false;
+  }
+
+  /**
+   * Install dependencies - should be overridden by subclasses that support it
+   */
+  async installDependencies() {
+    throw new Error('installDependencies() not supported by this scaffolder');
+  }
+
+  /**
+   * Initialize git repository
+   */
+  async initializeGit() {
+    try {
+      process.chdir(this.targetDirectory);
+      
+      execSync('git init', { stdio: 'pipe' });
+      
+      // Create .gitignore if it doesn't exist
+      const gitignorePath = join(this.targetDirectory, '.gitignore');
+      if (!existsSync(gitignorePath)) {
+        this.writeFile('.gitignore', this.getDefaultGitignore());
+      }
+      
+      execSync('git add .', { stdio: 'pipe' });
+      execSync('git commit -m "Initial commit from initrepo scaffold"', { stdio: 'pipe' });
+      
+    } catch (error) {
+      console.warn(colors.yellow('⚠️'), 'Could not initialize git repository:', error.message);
+    }
+  }
+
+  /**
+   * Get default .gitignore content - should be overridden by subclasses
+   */
+  getDefaultGitignore() {
+    return `# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Production
+/build
+/dist
+
+# Environment variables
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+`;
+  }
+
+  /**
+   * Create a directory if it doesn't exist
+   */
+  createDirectory(relativePath) {
+    const fullPath = join(this.targetDirectory, relativePath);
+    if (!existsSync(fullPath)) {
+      mkdirSync(fullPath, { recursive: true });
+    }
+  }
+
+  /**
+   * Write a file with content
+   */
+  writeFile(relativePath, content) {
+    const fullPath = join(this.targetDirectory, relativePath);
+    const dir = dirname(fullPath);
+    
+    // Ensure directory exists
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    
+    writeFileSync(fullPath, content, 'utf-8');
+  }
+
+  /**
+   * Get project name in various formats
+   */
+  getProjectNames() {
+    return {
+      original: this.projectName,
+      kebab: this.projectName.toLowerCase().replace(/[^a-z0-9]/g, '-'),
+      camel: this.projectName.replace(/[^a-zA-Z0-9]/g, '').replace(/^./, str => str.toLowerCase()),
+      pascal: this.projectName.replace(/[^a-zA-Z0-9]/g, '').replace(/^./, str => str.toUpperCase()),
+      snake: this.projectName.toLowerCase().replace(/[^a-z0-9]/g, '_')
+    };
+  }
+
+  /**
+   * Replace template variables in content
+   */
+  replaceTemplateVariables(content) {
+    const names = this.getProjectNames();
+    
+    return content
+      .replace(/{{PROJECT_NAME}}/g, names.original)
+      .replace(/{{PROJECT_NAME_KEBAB}}/g, names.kebab)
+      .replace(/{{PROJECT_NAME_CAMEL}}/g, names.camel)
+      .replace(/{{PROJECT_NAME_PASCAL}}/g, names.pascal)
+      .replace(/{{PROJECT_NAME_SNAKE}}/g, names.snake)
+      .replace(/{{CURRENT_YEAR}}/g, new Date().getFullYear().toString())
+      .replace(/{{CURRENT_DATE}}/g, new Date().toISOString().split('T')[0]);
+  }
+
+  /**
+   * Create standard project structure from architecture or default
+   */
+  createStructureFromArchitecture() {
+    if (!this.architecture || !this.architecture.structure) {
+      return this.createDefaultStructure();
+    }
+
+    const { directories, files } = this.architecture.structure;
+
+    // Create directories
+    directories.forEach(dir => {
+      this.createDirectory(dir);
+    });
+
+    // Create placeholder files or use templates
+    files.forEach(file => {
+      const content = this.getFileTemplate(file);
+      this.writeFile(file, content);
+    });
+  }
+
+  /**
+   * Create default structure - should be overridden by subclasses
+   */
+  createDefaultStructure() {
+    throw new Error('createDefaultStructure() must be implemented by subclass');
+  }
+
+  /**
+   * Get template content for a file - should be overridden by subclasses
+   */
+  getFileTemplate(filePath) {
+    return `// ${filePath}\n// Generated by initrepo scaffold\n`;
+  }
+
+  /**
+   * Log progress message
+   */
+  log(message, type = 'info') {
+    const colors_map = {
+      info: colors.blue,
+      success: colors.green,
+      warning: colors.yellow,
+      error: colors.red
+    };
+    
+    const colorFn = colors_map[type] || colors.blue;
+    console.log(colorFn(`  ${message}`));
+  }
+}

--- a/src/scaffolders/nextjs-scaffolder.js
+++ b/src/scaffolders/nextjs-scaffolder.js
@@ -1,0 +1,409 @@
+/**
+ * Next.js Scaffolder
+ * 
+ * Creates a complete Next.js project structure with App Router,
+ * TypeScript, Tailwind CSS, and best practices setup.
+ */
+
+import { BaseScaffolder } from './base-scaffolder.js';
+import { execSync } from 'child_process';
+
+export class NextJSScaffolder extends BaseScaffolder {
+  constructor(options) {
+    super(options);
+    this.useTypeScript = options.typescript !== false;
+    this.useTailwind = options.tailwind !== false;
+    this.useAuth = options.auth || (this.architecture?.configuration?.authentication);
+    this.useDatabase = options.database || (this.architecture?.configuration?.database);
+  }
+
+  async scaffold() {
+    // Create package.json
+    this.createPackageJson();
+    
+    // Create Next.js configuration
+    this.createNextConfig();
+    
+    // Create TypeScript configuration if needed
+    if (this.useTypeScript) {
+      this.createTypeScriptConfig();
+    }
+    
+    // Create Tailwind configuration if needed
+    if (this.useTailwind) {
+      this.createTailwindConfig();
+    }
+    
+    // Create project structure
+    if (this.architecture?.structure) {
+      this.createStructureFromArchitecture();
+    } else {
+      this.createDefaultStructure();
+    }
+    
+    // Create essential files
+    this.createEssentialFiles();
+  }
+
+  createDefaultStructure() {
+    const dirs = [
+      'app',
+      'app/components',
+      'app/utils',
+      'app/lib',
+      'app/api',
+      'app/dashboard',
+      'app/login',
+      'app/signup',
+      'public',
+      'components/ui',
+      'lib',
+      'utils'
+    ];
+
+    dirs.forEach(dir => this.createDirectory(dir));
+
+    // Create essential app files
+    this.createAppFiles();
+  }
+
+  createPackageJson() {
+    const packageJson = {
+      name: this.getProjectNames().kebab,
+      version: "0.1.0",
+      private: true,
+      scripts: {
+        dev: "next dev",
+        build: "next build",
+        start: "next start",
+        lint: "next lint",
+        ...(this.useTypeScript && { "type-check": "tsc --noEmit" })
+      },
+      dependencies: {
+        next: "^14.0.0",
+        react: "^18.0.0",
+        "react-dom": "^18.0.0",
+        ...(this.useTailwind && {
+          "tailwindcss": "^3.3.0",
+          "autoprefixer": "^10.4.16",
+          "postcss": "^8.4.31"
+        }),
+        ...(this.useAuth === 'clerk' && {
+          "@clerk/nextjs": "^4.27.0"
+        }),
+        ...(this.useDatabase === 'prisma' && {
+          "@prisma/client": "^5.6.0",
+          "prisma": "^5.6.0"
+        })
+      },
+      devDependencies: {
+        ...(this.useTypeScript && {
+          typescript: "^5.0.0",
+          "@types/node": "^20.0.0",
+          "@types/react": "^18.0.0",
+          "@types/react-dom": "^18.0.0"
+        }),
+        eslint: "^8.0.0",
+        "eslint-config-next": "^14.0.0"
+      }
+    };
+
+    this.writeFile('package.json', JSON.stringify(packageJson, null, 2));
+  }
+
+  createNextConfig() {
+    const config = `/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+  images: {
+    domains: [],
+  },
+}
+
+module.exports = nextConfig
+`;
+    this.writeFile('next.config.js', config);
+  }
+
+  createTypeScriptConfig() {
+    const tsConfig = {
+      compilerOptions: {
+        target: "es5",
+        lib: ["dom", "dom.iterable", "es6"],
+        allowJs: true,
+        skipLibCheck: true,
+        strict: true,
+        noEmit: true,
+        esModuleInterop: true,
+        module: "esnext",
+        moduleResolution: "bundler",
+        resolveJsonModule: true,
+        isolatedModules: true,
+        jsx: "preserve",
+        incremental: true,
+        plugins: [
+          {
+            name: "next"
+          }
+        ],
+        baseUrl: ".",
+        paths: {
+          "@/*": ["./*"]
+        }
+      },
+      include: ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+      exclude: ["node_modules"]
+    };
+
+    this.writeFile('tsconfig.json', JSON.stringify(tsConfig, null, 2));
+  }
+
+  createTailwindConfig() {
+    const tailwindConfig = `/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      backgroundImage: {
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic':
+          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+      },
+    },
+  },
+  plugins: [],
+}
+`;
+
+    this.writeFile('tailwind.config.js', tailwindConfig);
+
+    const postcssConfig = `module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}
+`;
+
+    this.writeFile('postcss.config.js', postcssConfig);
+  }
+
+  createAppFiles() {
+    const fileExt = this.useTypeScript ? 'tsx' : 'jsx';
+    
+    // Root layout
+    const layoutContent = `${this.useTypeScript ? "import type { Metadata } from 'next'\n" : ""}import { Inter } from 'next/font/google'
+${this.useTailwind ? "import './globals.css'" : ""}
+
+const inter = Inter({ subsets: ['latin'] })
+
+${this.useTypeScript ? `export const metadata: Metadata = {
+  title: '${this.projectName}',
+  description: 'Generated by initrepo scaffold',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {` : `export default function RootLayout({ children }) {`}
+  return (
+    <html lang="en">
+      <body className={${this.useTailwind ? 'inter.className' : '"font-sans"'}}>{children}</body>
+    </html>
+  )
+}
+`;
+
+    this.writeFile(`app/layout.${fileExt}`, layoutContent);
+
+    // Home page
+    const pageContent = `export default function Home() {
+  return (
+    <main className="${this.useTailwind ? 'flex min-h-screen flex-col items-center justify-between p-24' : 'padding: 2rem'}">
+      <div className="${this.useTailwind ? 'z-10 max-w-5xl w-full items-center justify-between font-mono text-sm' : ''}">
+        <h1 className="${this.useTailwind ? 'text-4xl font-bold text-center' : 'text-center'}">
+          Welcome to ${this.projectName}
+        </h1>
+        <p className="${this.useTailwind ? 'text-center mt-4 text-gray-600' : 'text-center margin-top: 1rem'}">
+          Generated with InitRepo CLI
+        </p>
+      </div>
+    </main>
+  )
+}
+`;
+
+    this.writeFile(`app/page.${fileExt}`, pageContent);
+
+    // Global styles
+    if (this.useTailwind) {
+      const globalCss = `@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --foreground-rgb: 0, 0, 0;
+  --background-start-rgb: 214, 219, 220;
+  --background-end-rgb: 255, 255, 255;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --foreground-rgb: 255, 255, 255;
+    --background-start-rgb: 0, 0, 0;
+    --background-end-rgb: 0, 0, 0;
+  }
+}
+
+body {
+  color: rgb(var(--foreground-rgb));
+  background: linear-gradient(
+      to bottom,
+      transparent,
+      rgb(var(--background-end-rgb))
+    )
+    rgb(var(--background-start-rgb));
+}
+`;
+      this.writeFile('app/globals.css', globalCss);
+    }
+  }
+
+  createEssentialFiles() {
+    // README.md
+    const readme = `# ${this.projectName}
+
+Generated with InitRepo CLI
+
+## Getting Started
+
+First, run the development server:
+
+\`\`\`bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+\`\`\`
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Project Structure
+
+- \`app/\` - Next.js App Router pages and layouts
+- \`components/\` - Reusable React components
+- \`lib/\` - Utility functions and configurations
+- \`public/\` - Static assets
+
+## Tech Stack
+
+- [Next.js](https://nextjs.org/) - React framework
+- [React](https://reactjs.org/) - UI library
+${this.useTypeScript ? '- [TypeScript](https://www.typescriptlang.org/) - Type safety\n' : ''}${this.useTailwind ? '- [Tailwind CSS](https://tailwindcss.com/) - Styling\n' : ''}
+## Learn More
+
+To learn more about Next.js, take a look at the following resources:
+
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+`;
+
+    this.writeFile('README.md', readme);
+
+    // Environment example
+    const envExample = `# Copy this to .env.local and fill in your values
+
+# Next.js
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=your-secret-here
+
+${this.useAuth === 'clerk' ? `# Clerk Authentication
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+` : ''}
+
+${this.useDatabase ? `# Database
+DATABASE_URL="your-database-url"
+` : ''}
+`;
+
+    this.writeFile('.env.example', envExample);
+  }
+
+  supportsDependencyInstallation() {
+    return true;
+  }
+
+  async installDependencies() {
+    try {
+      process.chdir(this.targetDirectory);
+      execSync('npm install', { stdio: 'inherit' });
+    } catch (error) {
+      this.log('Failed to install dependencies: ' + error.message, 'warning');
+    }
+  }
+
+  getNextSteps() {
+    const steps = [
+      'npm run dev',
+      'Open http://localhost:3000 in your browser'
+    ];
+
+    if (this.useAuth) {
+      steps.push('Configure authentication in .env.local');
+    }
+
+    if (this.useDatabase) {
+      steps.push('Set up your database connection');
+    }
+
+    return steps;
+  }
+
+  getDefaultGitignore() {
+    return `# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+`;
+  }
+}

--- a/src/scaffolders/python-automation-scaffolder.js
+++ b/src/scaffolders/python-automation-scaffolder.js
@@ -1,0 +1,1733 @@
+/**
+ * Python Automation Scaffolder
+ * 
+ * Creates a Python automation project structure for scripts,
+ * workflows, and automation tasks.
+ */
+
+import { BaseScaffolder } from './base-scaffolder.js';
+import { execSync } from 'child_process';
+
+export class PythonAutomationScaffolder extends BaseScaffolder {
+  constructor(options) {
+    super(options);
+    this.usePoetry = options.poetry !== false;
+    this.includeScheduler = options.scheduler !== false;
+    this.includeWebInterface = options.web !== false;
+  }
+
+  async scaffold() {
+    this.createProjectFiles();
+    
+    if (this.architecture?.structure) {
+      this.createStructureFromArchitecture();
+    } else {
+      this.createDefaultStructure();
+    }
+    
+    this.createEssentialFiles();
+  }
+
+  createDefaultStructure() {
+    const dirs = [
+      'src',
+      `src/${this.getProjectNames().snake}`,
+      `src/${this.getProjectNames().snake}/tasks`,
+      `src/${this.getProjectNames().snake}/workflows`,
+      `src/${this.getProjectNames().snake}/utils`,
+      `src/${this.getProjectNames().snake}/config`,
+      'scripts',
+      'data',
+      'data/input',
+      'data/output',
+      'data/temp',
+      'logs',
+      'tests',
+      'tests/tasks',
+      'tests/workflows',
+      'docs',
+      'examples'
+    ];
+
+    if (this.includeWebInterface) {
+      dirs.push(`src/${this.getProjectNames().snake}/web`);
+      dirs.push(`src/${this.getProjectNames().snake}/web/templates`);
+      dirs.push(`src/${this.getProjectNames().snake}/web/static`);
+    }
+
+    dirs.forEach(dir => this.createDirectory(dir));
+    this.createSourceFiles();
+  }
+
+  createProjectFiles() {
+    if (this.usePoetry) {
+      this.createPyprojectToml();
+    } else {
+      this.createSetupPy();
+      this.createRequirementsTxt();
+    }
+  }
+
+  createPyprojectToml() {
+    const projectName = this.getProjectNames().kebab;
+    const packageName = this.getProjectNames().snake;
+    
+    const pyprojectContent = `[tool.poetry]
+name = "${projectName}"
+version = "0.1.0"
+description = "Automation scripts and workflows for ${this.projectName}"
+authors = ["Your Name <your.email@example.com>"]
+readme = "README.md"
+packages = [{include = "${packageName}", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+click = "^8.1.0"
+pydantic = "^2.0.0"
+python-dotenv = "^1.0.0"
+loguru = "^0.7.0"
+pyyaml = "^6.0.1"
+requests = "^2.31.0"
+${this.includeScheduler ? 'schedule = "^1.2.0"\napscheduler = "^3.10.0"\n' : ''}${this.includeWebInterface ? 'fastapi = "^0.104.0"\nuvicorn = "^0.24.0"\njinja2 = "^3.1.0"\n' : ''}pandas = "^2.1.0"
+openpyxl = "^3.1.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.0"
+pytest-asyncio = "^0.21.0"
+black = "^23.0.0"
+isort = "^5.12.0"
+flake8 = "^6.0.0"
+mypy = "^1.5.0"
+pre-commit = "^3.4.0"
+
+[tool.poetry.scripts]
+${projectName} = "${packageName}.cli:main"
+${projectName}-server = "${packageName}.server:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+`;
+
+    this.writeFile('pyproject.toml', pyprojectContent);
+  }
+
+  createSetupPy() {
+    const packageName = this.getProjectNames().snake;
+    
+    const setupContent = `from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+with open("requirements.txt", "r", encoding="utf-8") as fh:
+    requirements = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
+
+setup(
+    name="${this.getProjectNames().kebab}",
+    version="0.1.0",
+    author="Your Name",
+    author_email="your.email@example.com",
+    description="Automation scripts and workflows for ${this.projectName}",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/yourusername/${this.getProjectNames().kebab}",
+    package_dir={"": "src"},
+    packages=find_packages(where="src"),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    python_requires=">=3.9",
+    install_requires=requirements,
+    extras_require={
+        "dev": [
+            "pytest>=7.4.0",
+            "black>=23.0.0",
+            "isort>=5.12.0",
+            "flake8>=6.0.0",
+            "mypy>=1.5.0",
+        ],
+        "web": [
+            "fastapi>=0.104.0",
+            "uvicorn>=0.24.0",
+            "jinja2>=3.1.0",
+        ],
+        "scheduler": [
+            "schedule>=1.2.0",
+            "apscheduler>=3.10.0",
+        ]
+    },
+    entry_points={
+        "console_scripts": [
+            "${this.getProjectNames().kebab}=${packageName}.cli:main",
+            "${this.getProjectNames().kebab}-server=${packageName}.server:main",
+        ],
+    },
+)
+`;
+
+    this.writeFile('setup.py', setupContent);
+  }
+
+  createRequirementsTxt() {
+    const requirements = `# Core dependencies
+click>=8.1.0
+pydantic>=2.0.0
+python-dotenv>=1.0.0
+loguru>=0.7.0
+pyyaml>=6.0.1
+requests>=2.31.0
+pandas>=2.1.0
+openpyxl>=3.1.0
+
+# Scheduling (optional)
+${this.includeScheduler ? `schedule>=1.2.0
+apscheduler>=3.10.0` : `# schedule>=1.2.0
+# apscheduler>=3.10.0`}
+
+# Web interface (optional)
+${this.includeWebInterface ? `fastapi>=0.104.0
+uvicorn>=0.24.0
+jinja2>=3.1.0` : `# fastapi>=0.104.0
+# uvicorn>=0.24.0
+# jinja2>=3.1.0`}
+`;
+
+    this.writeFile('requirements.txt', requirements);
+  }
+
+  createSourceFiles() {
+    const packageName = this.getProjectNames().snake;
+    
+    // Main package init
+    const initContent = `"""
+${this.projectName} Automation Package
+
+A comprehensive automation framework for scripts, workflows, and tasks.
+"""
+
+__version__ = "0.1.0"
+__author__ = "Your Name"
+__email__ = "your.email@example.com"
+
+from .config import settings
+from .tasks import TaskManager
+from .workflows import WorkflowManager
+
+__all__ = ["settings", "TaskManager", "WorkflowManager"]
+`;
+
+    this.writeFile(`src/${packageName}/__init__.py`, initContent);
+
+    // CLI interface
+    const cliContent = `"""
+Command Line Interface for ${this.projectName} automation.
+"""
+
+import click
+from loguru import logger
+
+from .config import settings
+from .tasks import TaskManager
+from .workflows import WorkflowManager
+
+
+@click.group()
+@click.option("--config", "-c", help="Configuration file path")
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
+def main(config: str = None, verbose: bool = False):
+    """${this.projectName} automation CLI."""
+    if verbose:
+        logger.add("logs/debug.log", level="DEBUG")
+    else:
+        logger.add("logs/app.log", level="INFO")
+    
+    if config:
+        settings.load_config(config)
+    
+    logger.info("Starting ${this.projectName} automation")
+
+
+@main.command()
+@click.argument("task_name")
+@click.option("--params", "-p", multiple=True, help="Task parameters (key=value)")
+def run_task(task_name: str, params: tuple):
+    """Run a specific task."""
+    task_manager = TaskManager()
+    
+    # Parse parameters
+    task_params = {}
+    for param in params:
+        if "=" in param:
+            key, value = param.split("=", 1)
+            task_params[key] = value
+    
+    logger.info(f"Running task: {task_name}")
+    result = task_manager.run_task(task_name, task_params)
+    
+    if result.success:
+        click.echo(f"Task completed successfully: {result.message}")
+    else:
+        click.echo(f"Task failed: {result.error}", err=True)
+        exit(1)
+
+
+@main.command()
+@click.argument("workflow_name")
+def run_workflow(workflow_name: str):
+    """Run a workflow."""
+    workflow_manager = WorkflowManager()
+    
+    logger.info(f"Running workflow: {workflow_name}")
+    result = workflow_manager.run_workflow(workflow_name)
+    
+    if result.success:
+        click.echo(f"Workflow completed successfully")
+    else:
+        click.echo(f"Workflow failed: {result.error}", err=True)
+        exit(1)
+
+
+@main.command()
+def list_tasks():
+    """List available tasks."""
+    task_manager = TaskManager()
+    tasks = task_manager.list_tasks()
+    
+    click.echo("Available tasks:")
+    for task in tasks:
+        click.echo(f"  - {task.name}: {task.description}")
+
+
+@main.command()
+def list_workflows():
+    """List available workflows."""
+    workflow_manager = WorkflowManager()
+    workflows = workflow_manager.list_workflows()
+    
+    click.echo("Available workflows:")
+    for workflow in workflows:
+        click.echo(f"  - {workflow.name}: {workflow.description}")
+
+
+${this.includeScheduler ? `@main.command()
+def scheduler():
+    """Start the task scheduler."""
+    from .scheduler import start_scheduler
+    
+    logger.info("Starting scheduler")
+    start_scheduler()` : ''}
+
+
+if __name__ == "__main__":
+    main()
+`;
+
+    this.writeFile(`src/${packageName}/cli.py`, cliContent);
+
+    // Configuration module
+    const configContent = `"""
+Configuration management for ${this.projectName}.
+"""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+from pydantic import BaseSettings, Field
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+
+class Settings(BaseSettings):
+    """Application settings."""
+    
+    # Basic settings
+    app_name: str = "${this.projectName}"
+    debug: bool = Field(default=False, env="DEBUG")
+    log_level: str = Field(default="INFO", env="LOG_LEVEL")
+    
+    # Directories
+    data_dir: str = Field(default="data", env="DATA_DIR")
+    logs_dir: str = Field(default="logs", env="LOGS_DIR")
+    temp_dir: str = Field(default="data/temp", env="TEMP_DIR")
+    
+    # Task settings
+    max_retries: int = Field(default=3, env="MAX_RETRIES")
+    retry_delay: int = Field(default=5, env="RETRY_DELAY")
+    timeout: int = Field(default=300, env="TIMEOUT")
+    
+    # Database (if needed)
+    database_url: Optional[str] = Field(default=None, env="DATABASE_URL")
+    
+    # API settings
+    api_host: str = Field(default="localhost", env="API_HOST")
+    api_port: int = Field(default=8000, env="API_PORT")
+    
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+    
+    def load_config(self, config_path: str):
+        """Load configuration from YAML file."""
+        config_file = Path(config_path)
+        if config_file.exists():
+            with open(config_file) as f:
+                config_data = yaml.safe_load(f)
+                for key, value in config_data.items():
+                    if hasattr(self, key):
+                        setattr(self, key, value)
+    
+    def ensure_directories(self):
+        """Ensure required directories exist."""
+        directories = [self.data_dir, self.logs_dir, self.temp_dir]
+        for directory in directories:
+            Path(directory).mkdir(parents=True, exist_ok=True)
+
+
+# Global settings instance
+settings = Settings()
+`;
+
+    this.writeFile(`src/${packageName}/config/__init__.py`, configContent);
+
+    // Task management
+    const tasksContent = `"""
+Task management system for ${this.projectName}.
+"""
+
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from loguru import logger
+from pydantic import BaseModel
+
+from ..config import settings
+
+
+class TaskResult(BaseModel):
+    """Result of a task execution."""
+    success: bool
+    message: str = ""
+    error: Optional[str] = None
+    data: Dict[str, Any] = {}
+    execution_time: float = 0.0
+
+
+@dataclass
+class Task:
+    """Task definition."""
+    name: str
+    description: str
+    function: callable
+    params: Dict[str, Any] = field(default_factory=dict)
+    retries: int = 3
+    timeout: int = 300
+
+
+class TaskManager:
+    """Manages and executes tasks."""
+    
+    def __init__(self):
+        self.tasks: Dict[str, Task] = {}
+        self._register_default_tasks()
+    
+    def register_task(self, task: Task):
+        """Register a new task."""
+        self.tasks[task.name] = task
+        logger.info(f"Registered task: {task.name}")
+    
+    def run_task(self, name: str, params: Dict[str, Any] = None) -> TaskResult:
+        """Run a task by name."""
+        if name not in self.tasks:
+            return TaskResult(
+                success=False,
+                error=f"Task '{name}' not found"
+            )
+        
+        task = self.tasks[name]
+        merged_params = {**task.params, **(params or {})}
+        
+        start_time = time.time()
+        
+        for attempt in range(task.retries + 1):
+            try:
+                logger.info(f"Running task '{name}' (attempt {attempt + 1})")
+                result_data = task.function(**merged_params)
+                
+                execution_time = time.time() - start_time
+                
+                return TaskResult(
+                    success=True,
+                    message=f"Task '{name}' completed successfully",
+                    data=result_data or {},
+                    execution_time=execution_time
+                )
+                
+            except Exception as e:
+                logger.error(f"Task '{name}' failed (attempt {attempt + 1}): {e}")
+                
+                if attempt == task.retries:
+                    execution_time = time.time() - start_time
+                    return TaskResult(
+                        success=False,
+                        error=str(e),
+                        execution_time=execution_time
+                    )
+                
+                time.sleep(settings.retry_delay)
+    
+    def list_tasks(self) -> List[Task]:
+        """List all registered tasks."""
+        return list(self.tasks.values())
+    
+    def _register_default_tasks(self):
+        """Register default tasks."""
+        # Example tasks
+        self.register_task(Task(
+            name="hello_world",
+            description="Simple hello world task",
+            function=self._hello_world_task
+        ))
+        
+        self.register_task(Task(
+            name="file_processor",
+            description="Process files in a directory",
+            function=self._file_processor_task
+        ))
+        
+        self.register_task(Task(
+            name="data_backup",
+            description="Backup data files",
+            function=self._data_backup_task
+        ))
+    
+    def _hello_world_task(self, message: str = "Hello, World!") -> Dict[str, Any]:
+        """Example hello world task."""
+        logger.info(f"Hello World Task: {message}")
+        return {"message": message, "timestamp": datetime.now().isoformat()}
+    
+    def _file_processor_task(self, input_dir: str = "data/input", 
+                           output_dir: str = "data/output") -> Dict[str, Any]:
+        """Example file processing task."""
+        input_path = Path(input_dir)
+        output_path = Path(output_dir)
+        
+        output_path.mkdir(parents=True, exist_ok=True)
+        
+        processed_files = []
+        
+        if input_path.exists():
+            for file_path in input_path.iterdir():
+                if file_path.is_file():
+                    logger.info(f"Processing file: {file_path}")
+                    
+                    # Simple file copy as example
+                    output_file = output_path / f"processed_{file_path.name}"
+                    output_file.write_bytes(file_path.read_bytes())
+                    
+                    processed_files.append(str(file_path))
+        
+        return {
+            "processed_files": processed_files,
+            "count": len(processed_files)
+        }
+    
+    def _data_backup_task(self, source_dir: str = "data", 
+                         backup_dir: str = "backup") -> Dict[str, Any]:
+        """Example data backup task."""
+        import shutil
+        from datetime import datetime
+        
+        source_path = Path(source_dir)
+        backup_path = Path(backup_dir)
+        
+        if not source_path.exists():
+            raise ValueError(f"Source directory does not exist: {source_dir}")
+        
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup_target = backup_path / f"backup_{timestamp}"
+        
+        logger.info(f"Creating backup: {backup_target}")
+        shutil.copytree(source_path, backup_target)
+        
+        return {
+            "source": str(source_path),
+            "backup": str(backup_target),
+            "timestamp": timestamp
+        }
+`;
+
+    this.writeFile(`src/${packageName}/tasks/__init__.py`, tasksContent);
+
+    // Workflow management
+    const workflowsContent = `"""
+Workflow management system for ${this.projectName}.
+"""
+
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, field
+from enum import Enum
+
+from loguru import logger
+from pydantic import BaseModel
+
+from ..tasks import TaskManager, TaskResult
+
+
+class WorkflowStatus(Enum):
+    """Workflow execution status."""
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class WorkflowResult(BaseModel):
+    """Result of a workflow execution."""
+    success: bool
+    status: WorkflowStatus
+    message: str = ""
+    error: Optional[str] = None
+    task_results: List[TaskResult] = []
+    execution_time: float = 0.0
+
+
+@dataclass
+class WorkflowStep:
+    """A single step in a workflow."""
+    task_name: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    depends_on: List[str] = field(default_factory=list)
+    optional: bool = False
+
+
+@dataclass
+class Workflow:
+    """Workflow definition."""
+    name: str
+    description: str
+    steps: List[WorkflowStep]
+    parallel: bool = False
+
+
+class WorkflowManager:
+    """Manages and executes workflows."""
+    
+    def __init__(self):
+        self.workflows: Dict[str, Workflow] = {}
+        self.task_manager = TaskManager()
+        self._register_default_workflows()
+    
+    def register_workflow(self, workflow: Workflow):
+        """Register a new workflow."""
+        self.workflows[workflow.name] = workflow
+        logger.info(f"Registered workflow: {workflow.name}")
+    
+    def run_workflow(self, name: str) -> WorkflowResult:
+        """Run a workflow by name."""
+        if name not in self.workflows:
+            return WorkflowResult(
+                success=False,
+                status=WorkflowStatus.FAILED,
+                error=f"Workflow '{name}' not found"
+            )
+        
+        workflow = self.workflows[name]
+        start_time = time.time()
+        task_results = []
+        
+        logger.info(f"Starting workflow: {name}")
+        
+        try:
+            if workflow.parallel:
+                task_results = self._run_parallel_workflow(workflow)
+            else:
+                task_results = self._run_sequential_workflow(workflow)
+            
+            execution_time = time.time() - start_time
+            
+            # Check if all required tasks succeeded
+            failed_tasks = [r for r in task_results if not r.success]
+            
+            if failed_tasks:
+                return WorkflowResult(
+                    success=False,
+                    status=WorkflowStatus.FAILED,
+                    error=f"Workflow failed: {len(failed_tasks)} tasks failed",
+                    task_results=task_results,
+                    execution_time=execution_time
+                )
+            
+            return WorkflowResult(
+                success=True,
+                status=WorkflowStatus.COMPLETED,
+                message=f"Workflow '{name}' completed successfully",
+                task_results=task_results,
+                execution_time=execution_time
+            )
+            
+        except Exception as e:
+            execution_time = time.time() - start_time
+            logger.error(f"Workflow '{name}' failed: {e}")
+            
+            return WorkflowResult(
+                success=False,
+                status=WorkflowStatus.FAILED,
+                error=str(e),
+                task_results=task_results,
+                execution_time=execution_time
+            )
+    
+    def _run_sequential_workflow(self, workflow: Workflow) -> List[TaskResult]:
+        """Run workflow steps sequentially."""
+        task_results = []
+        
+        for step in workflow.steps:
+            logger.info(f"Executing step: {step.task_name}")
+            
+            result = self.task_manager.run_task(step.task_name, step.params)
+            task_results.append(result)
+            
+            if not result.success and not step.optional:
+                logger.error(f"Required step '{step.task_name}' failed, stopping workflow")
+                break
+        
+        return task_results
+    
+    def _run_parallel_workflow(self, workflow: Workflow) -> List[TaskResult]:
+        """Run workflow steps in parallel (simplified implementation)."""
+        # For now, just run sequentially
+        # In a real implementation, you'd use threading or asyncio
+        return self._run_sequential_workflow(workflow)
+    
+    def list_workflows(self) -> List[Workflow]:
+        """List all registered workflows."""
+        return list(self.workflows.values())
+    
+    def _register_default_workflows(self):
+        """Register default workflows."""
+        # Example: Data processing workflow
+        data_processing = Workflow(
+            name="data_processing",
+            description="Complete data processing pipeline",
+            steps=[
+                WorkflowStep(
+                    task_name="file_processor",
+                    params={"input_dir": "data/input", "output_dir": "data/processed"}
+                ),
+                WorkflowStep(
+                    task_name="data_backup",
+                    params={"source_dir": "data/processed"}
+                )
+            ]
+        )
+        self.register_workflow(data_processing)
+        
+        # Example: Daily maintenance workflow
+        maintenance = Workflow(
+            name="daily_maintenance",
+            description="Daily maintenance tasks",
+            steps=[
+                WorkflowStep(
+                    task_name="data_backup",
+                    params={"source_dir": "data"}
+                ),
+                WorkflowStep(
+                    task_name="hello_world",
+                    params={"message": "Daily maintenance completed"},
+                    optional=True
+                )
+            ]
+        )
+        self.register_workflow(maintenance)
+`;
+
+    this.writeFile(`src/${packageName}/workflows/__init__.py`, workflowsContent);
+
+    // Utilities
+    const utilsContent = `"""
+Utility functions for ${this.projectName}.
+"""
+
+import os
+import json
+import csv
+from pathlib import Path
+from typing import Any, Dict, List, Union
+from datetime import datetime
+
+import pandas as pd
+from loguru import logger
+
+
+def read_file(file_path: Union[str, Path], encoding: str = "utf-8") -> str:
+    """Read text file content."""
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+    
+    return path.read_text(encoding=encoding)
+
+
+def write_file(file_path: Union[str, Path], content: str, encoding: str = "utf-8"):
+    """Write content to text file."""
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding=encoding)
+
+
+def read_json(file_path: Union[str, Path]) -> Dict[str, Any]:
+    """Read JSON file."""
+    content = read_file(file_path)
+    return json.loads(content)
+
+
+def write_json(file_path: Union[str, Path], data: Dict[str, Any], indent: int = 2):
+    """Write data to JSON file."""
+    content = json.dumps(data, indent=indent, ensure_ascii=False)
+    write_file(file_path, content)
+
+
+def read_csv(file_path: Union[str, Path]) -> List[Dict[str, Any]]:
+    """Read CSV file as list of dictionaries."""
+    path = Path(file_path)
+    with open(path, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def write_csv(file_path: Union[str, Path], data: List[Dict[str, Any]]):
+    """Write data to CSV file."""
+    if not data:
+        return
+    
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=data[0].keys())
+        writer.writeheader()
+        writer.writerows(data)
+
+
+def read_excel(file_path: Union[str, Path], sheet_name: str = None) -> pd.DataFrame:
+    """Read Excel file."""
+    return pd.read_excel(file_path, sheet_name=sheet_name)
+
+
+def write_excel(file_path: Union[str, Path], data: pd.DataFrame, sheet_name: str = "Sheet1"):
+    """Write DataFrame to Excel file."""
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data.to_excel(path, sheet_name=sheet_name, index=False)
+
+
+def ensure_directory(directory: Union[str, Path]):
+    """Ensure directory exists."""
+    Path(directory).mkdir(parents=True, exist_ok=True)
+
+
+def get_timestamp(format_str: str = "%Y%m%d_%H%M%S") -> str:
+    """Get current timestamp as string."""
+    return datetime.now().strftime(format_str)
+
+
+def get_file_size(file_path: Union[str, Path]) -> int:
+    """Get file size in bytes."""
+    return Path(file_path).stat().st_size
+
+
+def get_file_modification_time(file_path: Union[str, Path]) -> datetime:
+    """Get file modification time."""
+    timestamp = Path(file_path).stat().st_mtime
+    return datetime.fromtimestamp(timestamp)
+
+
+class FileWatcher:
+    """Simple file watcher utility."""
+    
+    def __init__(self, directory: Union[str, Path]):
+        self.directory = Path(directory)
+        self.last_check = {}
+    
+    def check_for_changes(self) -> List[Path]:
+        """Check for file changes since last check."""
+        changes = []
+        
+        if not self.directory.exists():
+            return changes
+        
+        for file_path in self.directory.rglob("*"):
+            if file_path.is_file():
+                mtime = file_path.stat().st_mtime
+                
+                if str(file_path) not in self.last_check:
+                    changes.append(file_path)
+                elif self.last_check[str(file_path)] != mtime:
+                    changes.append(file_path)
+                
+                self.last_check[str(file_path)] = mtime
+        
+        return changes
+
+
+def retry_on_failure(max_retries: int = 3, delay: float = 1.0):
+    """Decorator to retry function on failure."""
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            for attempt in range(max_retries):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    if attempt == max_retries - 1:
+                        raise e
+                    
+                    logger.warning(f"Attempt {attempt + 1} failed: {e}")
+                    time.sleep(delay)
+            
+        return wrapper
+    return decorator
+`;
+
+    this.writeFile(`src/${packageName}/utils/__init__.py`, utilsContent);
+
+    if (this.includeWebInterface) {
+      this.createWebInterface();
+    }
+
+    if (this.includeScheduler) {
+      this.createScheduler();
+    }
+  }
+
+  createWebInterface() {
+    const packageName = this.getProjectNames().snake;
+    
+    // Web server
+    const serverContent = `"""
+Web interface for ${this.projectName} automation.
+"""
+
+from fastapi import FastAPI, Request, Form, BackgroundTasks
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import HTMLResponse, JSONResponse
+import uvicorn
+
+from ..tasks import TaskManager, TaskResult
+from ..workflows import WorkflowManager, WorkflowResult
+from ..config import settings
+
+app = FastAPI(title="${this.projectName} Automation")
+
+# Mount static files and templates
+app.mount("/static", StaticFiles(directory="src/${packageName}/web/static"), name="static")
+templates = Jinja2Templates(directory="src/${packageName}/web/templates")
+
+# Initialize managers
+task_manager = TaskManager()
+workflow_manager = WorkflowManager()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def dashboard(request: Request):
+    """Main dashboard."""
+    tasks = task_manager.list_tasks()
+    workflows = workflow_manager.list_workflows()
+    
+    return templates.TemplateResponse("dashboard.html", {
+        "request": request,
+        "tasks": tasks,
+        "workflows": workflows
+    })
+
+
+@app.get("/api/tasks", response_model=list)
+async def api_list_tasks():
+    """API endpoint to list tasks."""
+    tasks = task_manager.list_tasks()
+    return [{"name": t.name, "description": t.description} for t in tasks]
+
+
+@app.post("/api/tasks/{task_name}/run")
+async def api_run_task(task_name: str, background_tasks: BackgroundTasks):
+    """API endpoint to run a task."""
+    def run_task_bg():
+        result = task_manager.run_task(task_name)
+        # In a real app, you'd store this result somewhere
+        
+    background_tasks.add_task(run_task_bg)
+    return {"message": f"Task {task_name} started"}
+
+
+@app.get("/api/workflows", response_model=list)
+async def api_list_workflows():
+    """API endpoint to list workflows."""
+    workflows = workflow_manager.list_workflows()
+    return [{"name": w.name, "description": w.description} for w in workflows]
+
+
+@app.post("/api/workflows/{workflow_name}/run")
+async def api_run_workflow(workflow_name: str, background_tasks: BackgroundTasks):
+    """API endpoint to run a workflow."""
+    def run_workflow_bg():
+        result = workflow_manager.run_workflow(workflow_name)
+        # In a real app, you'd store this result somewhere
+        
+    background_tasks.add_task(run_workflow_bg)
+    return {"message": f"Workflow {workflow_name} started"}
+
+
+def main():
+    """Start the web server."""
+    uvicorn.run(
+        "src.${packageName}.server:app",
+        host=settings.api_host,
+        port=settings.api_port,
+        reload=settings.debug
+    )
+
+
+if __name__ == "__main__":
+    main()
+`;
+
+    this.writeFile(`src/${packageName}/server.py`, serverContent);
+
+    // Dashboard template
+    const dashboardTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${this.projectName} Automation Dashboard</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            margin-bottom: 30px;
+        }
+        .section {
+            margin-bottom: 40px;
+        }
+        .section h2 {
+            color: #555;
+            border-bottom: 2px solid #e0e0e0;
+            padding-bottom: 10px;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 20px;
+        }
+        .card {
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            padding: 15px;
+            background: #fafafa;
+        }
+        .card h3 {
+            margin-top: 0;
+            color: #333;
+        }
+        .card p {
+            color: #666;
+            margin-bottom: 15px;
+        }
+        .btn {
+            background: #007bff;
+            color: white;
+            border: none;
+            padding: 8px 16px;
+            border-radius: 4px;
+            cursor: pointer;
+            text-decoration: none;
+            display: inline-block;
+        }
+        .btn:hover {
+            background: #0056b3;
+        }
+        .btn-success {
+            background: #28a745;
+        }
+        .btn-success:hover {
+            background: #1e7e34;
+        }
+        .status {
+            padding: 20px;
+            background: #e7f3ff;
+            border-radius: 4px;
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>${this.projectName} Automation Dashboard</h1>
+        
+        <div class="status">
+            <strong>System Status:</strong> Running | 
+            <strong>Tasks Available:</strong> {{ tasks|length }} | 
+            <strong>Workflows Available:</strong> {{ workflows|length }}
+        </div>
+
+        <div class="section">
+            <h2>Available Tasks</h2>
+            <div class="grid">
+                {% for task in tasks %}
+                <div class="card">
+                    <h3>{{ task.name }}</h3>
+                    <p>{{ task.description }}</p>
+                    <button class="btn" onclick="runTask('{{ task.name }}')">Run Task</button>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>Available Workflows</h2>
+            <div class="grid">
+                {% for workflow in workflows %}
+                <div class="card">
+                    <h3>{{ workflow.name }}</h3>
+                    <p>{{ workflow.description }}</p>
+                    <button class="btn btn-success" onclick="runWorkflow('{{ workflow.name }}')">Run Workflow</button>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <script>
+        async function runTask(taskName) {
+            try {
+                const response = await fetch(\`/api/tasks/\${taskName}/run\`, {
+                    method: 'POST'
+                });
+                const result = await response.json();
+                alert(result.message);
+            } catch (error) {
+                alert('Error running task: ' + error.message);
+            }
+        }
+
+        async function runWorkflow(workflowName) {
+            try {
+                const response = await fetch(\`/api/workflows/\${workflowName}/run\`, {
+                    method: 'POST'
+                });
+                const result = await response.json();
+                alert(result.message);
+            } catch (error) {
+                alert('Error running workflow: ' + error.message);
+            }
+        }
+    </script>
+</body>
+</html>
+`;
+
+    this.writeFile(`src/${packageName}/web/templates/dashboard.html`, dashboardTemplate);
+
+    // Static CSS (placeholder)
+    const staticCss = `/* Additional styles for ${this.projectName} */
+.custom-styles {
+    /* Add your custom styles here */
+}
+`;
+
+    this.writeFile(`src/${packageName}/web/static/styles.css`, staticCss);
+  }
+
+  createScheduler() {
+    const packageName = this.getProjectNames().snake;
+    
+    const schedulerContent = `"""
+Task scheduler for ${this.projectName}.
+"""
+
+import time
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+import schedule
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+from loguru import logger
+
+from .tasks import TaskManager
+from .workflows import WorkflowManager
+from .config import settings
+
+
+class TaskScheduler:
+    """Scheduler for automating task and workflow execution."""
+    
+    def __init__(self):
+        self.task_manager = TaskManager()
+        self.workflow_manager = WorkflowManager()
+        self.scheduler = BlockingScheduler()
+        self._setup_default_schedules()
+    
+    def schedule_task(self, task_name: str, cron_expression: str, params: Dict = None):
+        """Schedule a task with cron expression."""
+        def job():
+            logger.info(f"Running scheduled task: {task_name}")
+            result = self.task_manager.run_task(task_name, params or {})
+            if result.success:
+                logger.info(f"Scheduled task '{task_name}' completed successfully")
+            else:
+                logger.error(f"Scheduled task '{task_name}' failed: {result.error}")
+        
+        trigger = CronTrigger.from_crontab(cron_expression)
+        self.scheduler.add_job(job, trigger, id=f"task_{task_name}")
+        logger.info(f"Scheduled task '{task_name}' with cron: {cron_expression}")
+    
+    def schedule_workflow(self, workflow_name: str, cron_expression: str):
+        """Schedule a workflow with cron expression."""
+        def job():
+            logger.info(f"Running scheduled workflow: {workflow_name}")
+            result = self.workflow_manager.run_workflow(workflow_name)
+            if result.success:
+                logger.info(f"Scheduled workflow '{workflow_name}' completed successfully")
+            else:
+                logger.error(f"Scheduled workflow '{workflow_name}' failed: {result.error}")
+        
+        trigger = CronTrigger.from_crontab(cron_expression)
+        self.scheduler.add_job(job, trigger, id=f"workflow_{workflow_name}")
+        logger.info(f"Scheduled workflow '{workflow_name}' with cron: {cron_expression}")
+    
+    def start(self):
+        """Start the scheduler."""
+        logger.info("Starting task scheduler")
+        try:
+            self.scheduler.start()
+        except KeyboardInterrupt:
+            logger.info("Scheduler stopped by user")
+            self.scheduler.shutdown()
+    
+    def _setup_default_schedules(self):
+        """Set up default scheduled tasks."""
+        # Example: Run data backup daily at 2 AM
+        self.schedule_task("data_backup", "0 2 * * *")
+        
+        # Example: Run maintenance workflow weekly on Sunday at 3 AM
+        self.schedule_workflow("daily_maintenance", "0 3 * * 0")
+
+
+def start_scheduler():
+    """Start the task scheduler."""
+    scheduler = TaskScheduler()
+    scheduler.start()
+
+
+# Simple schedule-based scheduler (alternative)
+class SimpleScheduler:
+    """Simple scheduler using the schedule library."""
+    
+    def __init__(self):
+        self.task_manager = TaskManager()
+        self.workflow_manager = WorkflowManager()
+        self._setup_schedules()
+    
+    def _setup_schedules(self):
+        """Set up scheduled tasks."""
+        # Daily backup at 2 AM
+        schedule.every().day.at("02:00").do(self._run_backup)
+        
+        # Weekly maintenance on Sunday at 3 AM
+        schedule.every().sunday.at("03:00").do(self._run_maintenance)
+        
+        # Hourly health check
+        schedule.every().hour.do(self._health_check)
+    
+    def _run_backup(self):
+        """Run backup task."""
+        logger.info("Running scheduled backup")
+        result = self.task_manager.run_task("data_backup")
+        return result.success
+    
+    def _run_maintenance(self):
+        """Run maintenance workflow."""
+        logger.info("Running scheduled maintenance")
+        result = self.workflow_manager.run_workflow("daily_maintenance")
+        return result.success
+    
+    def _health_check(self):
+        """Simple health check."""
+        logger.info("Health check - system running normally")
+        return True
+    
+    def start(self):
+        """Start the simple scheduler."""
+        logger.info("Starting simple scheduler")
+        
+        while True:
+            schedule.run_pending()
+            time.sleep(60)  # Check every minute
+`;
+
+    this.writeFile(`src/${packageName}/scheduler.py`, schedulerContent);
+  }
+
+  createEssentialFiles() {
+    const packageName = this.getProjectNames().snake;
+    
+    // README
+    const readme = `# ${this.projectName}
+
+A comprehensive Python automation framework for scripts, workflows, and scheduled tasks.
+
+## Features
+
+- **Task Management**: Define and execute individual automation tasks
+- **Workflow Engine**: Chain tasks together into complex workflows
+- **CLI Interface**: Command-line tools for running tasks and workflows
+${this.includeScheduler ? '- **Scheduler**: Automated task scheduling with cron-like expressions\n' : ''}${this.includeWebInterface ? '- **Web Interface**: Browser-based dashboard for monitoring and control\n' : ''}- **Configuration Management**: Flexible configuration with environment variables
+- **Logging**: Comprehensive logging with loguru
+- **Data Processing**: Built-in support for CSV, JSON, Excel files
+
+## Installation
+
+### Using Poetry (Recommended)
+
+\`\`\`bash
+poetry install
+\`\`\`
+
+### Using pip
+
+\`\`\`bash
+pip install -r requirements.txt
+\`\`\`
+
+## Quick Start
+
+### Running Tasks
+
+\`\`\`bash
+# List available tasks
+${this.getProjectNames().kebab} list-tasks
+
+# Run a specific task
+${this.getProjectNames().kebab} run-task hello_world
+
+# Run task with parameters
+${this.getProjectNames().kebab} run-task file_processor -p input_dir=data/input -p output_dir=data/output
+\`\`\`
+
+### Running Workflows
+
+\`\`\`bash
+# List available workflows
+${this.getProjectNames().kebab} list-workflows
+
+# Run a workflow
+${this.getProjectNames().kebab} run-workflow data_processing
+\`\`\`
+
+${this.includeScheduler ? `### Starting the Scheduler
+
+\`\`\`bash
+# Start the task scheduler
+${this.getProjectNames().kebab} scheduler
+\`\`\`
+` : ''}
+
+${this.includeWebInterface ? `### Web Interface
+
+\`\`\`bash
+# Start the web server
+${this.getProjectNames().kebab}-server
+
+# Access dashboard at http://localhost:8000
+\`\`\`
+` : ''}
+
+## Configuration
+
+Create a \`.env\` file in the project root:
+
+\`\`\`env
+DEBUG=false
+LOG_LEVEL=INFO
+DATA_DIR=data
+LOGS_DIR=logs
+MAX_RETRIES=3
+RETRY_DELAY=5
+TIMEOUT=300
+${this.includeWebInterface ? `
+# Web interface settings
+API_HOST=localhost
+API_PORT=8000` : ''}
+\`\`\`
+
+## Project Structure
+
+\`\`\`
+src/${packageName}/
+├── __init__.py          # Package initialization
+├── cli.py              # Command-line interface
+├── config/             # Configuration management
+├── tasks/              # Task definitions and management
+├── workflows/          # Workflow definitions and execution
+├── utils/              # Utility functions
+${this.includeScheduler ? '├── scheduler.py        # Task scheduling\n' : ''}${this.includeWebInterface ? '├── server.py           # Web interface\n├── web/                # Web templates and static files\n' : ''}data/
+├── input/              # Input files
+├── output/             # Processed output files
+└── temp/               # Temporary files
+logs/                   # Application logs
+scripts/                # Additional utility scripts
+\`\`\`
+
+## Creating Custom Tasks
+
+Define new tasks by adding them to the TaskManager:
+
+\`\`\`python
+from ${packageName}.tasks import TaskManager, Task
+
+def my_custom_task(param1: str, param2: int = 10) -> dict:
+    # Your task logic here
+    return {"result": f"Processed {param1} with {param2}"}
+
+task_manager = TaskManager()
+task_manager.register_task(Task(
+    name="my_custom_task",
+    description="Description of what this task does",
+    function=my_custom_task
+))
+\`\`\`
+
+## Creating Custom Workflows
+
+Define workflows by specifying a sequence of tasks:
+
+\`\`\`python
+from ${packageName}.workflows import WorkflowManager, Workflow, WorkflowStep
+
+workflow = Workflow(
+    name="my_workflow",
+    description="Custom workflow description",
+    steps=[
+        WorkflowStep(
+            task_name="task1",
+            params={"param": "value"}
+        ),
+        WorkflowStep(
+            task_name="task2",
+            depends_on=["task1"]
+        )
+    ]
+)
+
+workflow_manager = WorkflowManager()
+workflow_manager.register_workflow(workflow)
+\`\`\`
+
+## Built-in Tasks
+
+- **hello_world**: Simple greeting task for testing
+- **file_processor**: Process files from input to output directory
+- **data_backup**: Create timestamped backups of data directories
+
+## Built-in Workflows
+
+- **data_processing**: Complete data processing pipeline
+- **daily_maintenance**: Daily maintenance tasks including backups
+
+## Development
+
+### Running Tests
+
+\`\`\`bash
+pytest
+\`\`\`
+
+### Code Formatting
+
+\`\`\`bash
+black src/ tests/
+isort src/ tests/
+\`\`\`
+
+### Type Checking
+
+\`\`\`bash
+mypy src/
+\`\`\`
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests for new functionality
+5. Run the test suite
+6. Submit a pull request
+
+## License
+
+This project is licensed under the MIT License. See LICENSE file for details.
+`;
+
+    this.writeFile('README.md', readme);
+
+    // Configuration files
+    const configYaml = `# ${this.projectName} Configuration
+
+# Application settings
+app_name: "${this.projectName}"
+debug: false
+log_level: "INFO"
+
+# Directories
+data_dir: "data"
+logs_dir: "logs"
+temp_dir: "data/temp"
+
+# Task settings
+max_retries: 3
+retry_delay: 5
+timeout: 300
+
+${this.includeWebInterface ? `# API settings
+api_host: "localhost"
+api_port: 8000
+` : ''}
+
+# Custom settings
+# Add your application-specific settings here
+`;
+
+    this.writeFile('config.yaml', configYaml);
+
+    // Environment template
+    const envExample = `# Environment Configuration for ${this.projectName}
+
+# Debug mode
+DEBUG=false
+
+# Logging
+LOG_LEVEL=INFO
+
+# Directories
+DATA_DIR=data
+LOGS_DIR=logs
+TEMP_DIR=data/temp
+
+# Task execution
+MAX_RETRIES=3
+RETRY_DELAY=5
+TIMEOUT=300
+
+${this.includeWebInterface ? `# Web interface
+API_HOST=localhost
+API_PORT=8000
+` : ''}
+
+# Database (if needed)
+# DATABASE_URL=sqlite:///app.db
+
+# External APIs
+# API_KEY=your-api-key-here
+# API_BASE_URL=https://api.example.com
+`;
+
+    this.writeFile('.env.example', envExample);
+
+    // Sample data
+    const sampleData = `name,value,category
+Sample 1,100,A
+Sample 2,200,B
+Sample 3,150,A
+Sample 4,300,C
+`;
+
+    this.writeFile('data/input/sample.csv', sampleData);
+
+    // Script examples
+    const runScript = `#!/bin/bash
+# Run ${this.projectName} automation
+
+echo "Starting ${this.projectName} automation..."
+
+# Activate virtual environment if using venv
+# source venv/bin/activate
+
+# Run with Poetry
+poetry run ${this.getProjectNames().kebab} "$@"
+
+# Or run with pip
+# python -m ${packageName}.cli "$@"
+`;
+
+    this.writeFile('scripts/run.sh', runScript);
+
+    // Make script executable
+    this.writeFile('scripts/run.bat', `@echo off
+REM Run ${this.projectName} automation on Windows
+
+echo Starting ${this.projectName} automation...
+
+REM Run with Poetry
+poetry run ${this.getProjectNames().kebab} %*
+
+REM Or run with pip
+REM python -m ${packageName}.cli %*
+`);
+  }
+
+  supportsDependencyInstallation() {
+    return true;
+  }
+
+  async installDependencies() {
+    try {
+      process.chdir(this.targetDirectory);
+      
+      if (this.usePoetry) {
+        execSync('poetry install', { stdio: 'inherit' });
+      } else {
+        execSync('pip install -r requirements.txt', { stdio: 'inherit' });
+      }
+    } catch (error) {
+      this.log('Failed to install dependencies: ' + error.message, 'warning');
+    }
+  }
+
+  getNextSteps() {
+    const steps = [];
+    
+    if (this.usePoetry) {
+      steps.push('poetry install');
+      steps.push('poetry run ' + this.getProjectNames().kebab + ' list-tasks');
+    } else {
+      steps.push('pip install -r requirements.txt');
+      steps.push('python -m ' + this.getProjectNames().snake + '.cli list-tasks');
+    }
+    
+    steps.push('Edit config.yaml or .env to customize settings');
+    
+    if (this.includeWebInterface) {
+      steps.push('Start web interface: ' + this.getProjectNames().kebab + '-server');
+    }
+    
+    if (this.includeScheduler) {
+      steps.push('Start scheduler: ' + this.getProjectNames().kebab + ' scheduler');
+    }
+    
+    return steps;
+  }
+
+  getDefaultGitignore() {
+    return `# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Poetry
+poetry.lock
+
+# Data and logs
+data/temp/
+logs/
+*.log
+
+# Configuration
+config.json
+.env.local
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+.cache/
+`;
+  }
+}

--- a/src/scaffolders/python-mcp-scaffolder.js
+++ b/src/scaffolders/python-mcp-scaffolder.js
@@ -1,0 +1,939 @@
+/**
+ * Python MCP Scaffolder
+ * 
+ * Creates a Python MCP (Model Context Protocol) server project structure
+ * for building AI tools and integrations.
+ */
+
+import { BaseScaffolder } from './base-scaffolder.js';
+import { execSync } from 'child_process';
+
+export class PythonMCPScaffolder extends BaseScaffolder {
+  constructor(options) {
+    super(options);
+    this.usePoetry = options.poetry !== false;
+    this.includeSamples = options.samples !== false;
+  }
+
+  async scaffold() {
+    this.createProjectFiles();
+    
+    if (this.architecture?.structure) {
+      this.createStructureFromArchitecture();
+    } else {
+      this.createDefaultStructure();
+    }
+    
+    this.createEssentialFiles();
+  }
+
+  createDefaultStructure() {
+    const dirs = [
+      'src',
+      `src/${this.getProjectNames().snake}`,
+      `src/${this.getProjectNames().snake}/tools`,
+      `src/${this.getProjectNames().snake}/handlers`,
+      `src/${this.getProjectNames().snake}/utils`,
+      'tests',
+      'tests/tools',
+      'tests/handlers',
+      'docs',
+      'examples'
+    ];
+
+    dirs.forEach(dir => this.createDirectory(dir));
+    this.createSourceFiles();
+  }
+
+  createProjectFiles() {
+    if (this.usePoetry) {
+      this.createPyprojectToml();
+    } else {
+      this.createSetupPy();
+      this.createRequirementsTxt();
+    }
+  }
+
+  createPyprojectToml() {
+    const projectName = this.getProjectNames().kebab;
+    const packageName = this.getProjectNames().snake;
+    
+    const pyprojectContent = `[tool.poetry]
+name = "${projectName}"
+version = "0.1.0"
+description = "MCP server for ${this.projectName}"
+authors = ["Your Name <your.email@example.com>"]
+readme = "README.md"
+packages = [{include = "${packageName}", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+mcp = "^1.0.0"
+pydantic = "^2.0.0"
+anyio = "^4.0.0"
+httpx = "^0.27.0"
+click = "^8.1.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.0"
+pytest-asyncio = "^0.21.0"
+black = "^23.0.0"
+isort = "^5.12.0"
+flake8 = "^6.0.0"
+mypy = "^1.5.0"
+pre-commit = "^3.4.0"
+
+[tool.poetry.scripts]
+${projectName} = "${packageName}.server:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+`;
+
+    this.writeFile('pyproject.toml', pyprojectContent);
+  }
+
+  createSetupPy() {
+    const packageName = this.getProjectNames().snake;
+    
+    const setupContent = `from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+with open("requirements.txt", "r", encoding="utf-8") as fh:
+    requirements = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
+
+setup(
+    name="${this.getProjectNames().kebab}",
+    version="0.1.0",
+    author="Your Name",
+    author_email="your.email@example.com",
+    description="MCP server for ${this.projectName}",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/yourusername/${this.getProjectNames().kebab}",
+    package_dir={"": "src"},
+    packages=find_packages(where="src"),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    python_requires=">=3.9",
+    install_requires=requirements,
+    extras_require={
+        "dev": [
+            "pytest>=7.4.0",
+            "pytest-asyncio>=0.21.0",
+            "black>=23.0.0",
+            "isort>=5.12.0",
+            "flake8>=6.0.0",
+            "mypy>=1.5.0",
+        ]
+    },
+    entry_points={
+        "console_scripts": [
+            "${this.getProjectNames().kebab}=${packageName}.server:main",
+        ],
+    },
+)
+`;
+
+    this.writeFile('setup.py', setupContent);
+  }
+
+  createRequirementsTxt() {
+    const requirements = `# Core MCP dependencies
+mcp>=1.0.0
+pydantic>=2.0.0
+anyio>=4.0.0
+httpx>=0.27.0
+click>=8.1.0
+
+# Optional dependencies for enhanced functionality
+python-dotenv>=1.0.0
+loguru>=0.7.0
+`;
+
+    this.writeFile('requirements.txt', requirements);
+  }
+
+  createSourceFiles() {
+    const packageName = this.getProjectNames().snake;
+    
+    // Main server file
+    const serverContent = `"""
+${this.projectName} MCP Server
+
+A Model Context Protocol server that provides tools and resources.
+"""
+
+import asyncio
+import logging
+from typing import Any, Sequence
+
+import click
+from mcp.server import Server
+from mcp.server.models import InitializationOptions
+from mcp.server.stdio import stdio_server
+from mcp.types import (
+    Resource,
+    Tool,
+    TextContent,
+    ImageContent,
+    EmbeddedResource,
+)
+
+from .tools import get_available_tools
+from .handlers import setup_handlers
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class ${this.getProjectNames().pascal}Server:
+    """Main MCP server class for ${this.projectName}."""
+    
+    def __init__(self):
+        self.server = Server("${this.getProjectNames().kebab}")
+        self._setup_handlers()
+    
+    def _setup_handlers(self):
+        """Set up request handlers for the server."""
+        setup_handlers(self.server)
+        
+        @self.server.list_tools()
+        async def handle_list_tools() -> list[Tool]:
+            """List available tools."""
+            return get_available_tools()
+        
+        @self.server.call_tool()
+        async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[TextContent | ImageContent | EmbeddedResource]:
+            """Handle tool execution."""
+            from .tools import execute_tool
+            
+            try:
+                result = await execute_tool(name, arguments or {})
+                return [TextContent(type="text", text=str(result))]
+            except Exception as e:
+                logger.error(f"Error executing tool {name}: {e}")
+                return [TextContent(type="text", text=f"Error: {str(e)}")]
+    
+    async def run(self):
+        """Run the server."""
+        async with stdio_server() as (read_stream, write_stream):
+            await self.server.run(
+                read_stream,
+                write_stream,
+                InitializationOptions(
+                    server_name="${this.getProjectNames().kebab}",
+                    server_version="0.1.0",
+                    capabilities=self.server.get_capabilities(
+                        notification_options=None,
+                        experimental_capabilities=None,
+                    ),
+                ),
+            )
+
+
+@click.command()
+@click.option("--debug", is_flag=True, help="Enable debug logging")
+def main(debug: bool = False):
+    """Run the ${this.projectName} MCP server."""
+    if debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+    
+    server = ${this.getProjectNames().pascal}Server()
+    asyncio.run(server.run())
+
+
+if __name__ == "__main__":
+    main()
+`;
+
+    this.writeFile(`src/${packageName}/server.py`, serverContent);
+
+    // Package init file
+    const initContent = `"""
+${this.projectName} MCP Server Package
+"""
+
+__version__ = "0.1.0"
+__author__ = "Your Name"
+__email__ = "your.email@example.com"
+
+from .server import ${this.getProjectNames().pascal}Server
+
+__all__ = ["${this.getProjectNames().pascal}Server"]
+`;
+
+    this.writeFile(`src/${packageName}/__init__.py`, initContent);
+
+    // Tools module
+    const toolsContent = `"""
+Tools for the ${this.projectName} MCP server.
+"""
+
+from typing import Any, Dict, List
+from mcp.types import Tool
+
+# Example tools - replace with your actual tools
+AVAILABLE_TOOLS = [
+    Tool(
+        name="echo",
+        description="Echo back the input text",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "Text to echo back"
+                }
+            },
+            "required": ["text"]
+        }
+    ),
+    Tool(
+        name="calculate",
+        description="Perform basic arithmetic calculations",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "Mathematical expression to evaluate (e.g., '2 + 2')"
+                }
+            },
+            "required": ["expression"]
+        }
+    )
+]
+
+
+def get_available_tools() -> List[Tool]:
+    """Get list of available tools."""
+    return AVAILABLE_TOOLS
+
+
+async def execute_tool(name: str, arguments: Dict[str, Any]) -> Any:
+    """Execute a tool with given arguments."""
+    if name == "echo":
+        return echo_tool(arguments)
+    elif name == "calculate":
+        return calculate_tool(arguments)
+    else:
+        raise ValueError(f"Unknown tool: {name}")
+
+
+def echo_tool(arguments: Dict[str, Any]) -> str:
+    """Echo tool implementation."""
+    text = arguments.get("text", "")
+    return f"Echo: {text}"
+
+
+def calculate_tool(arguments: Dict[str, Any]) -> str:
+    """Calculate tool implementation."""
+    expression = arguments.get("expression", "")
+    
+    try:
+        # Simple and safe expression evaluation
+        # In production, consider using a proper math parser
+        allowed_chars = set("0123456789+-*/(). ")
+        if not all(c in allowed_chars for c in expression):
+            return "Error: Invalid characters in expression"
+        
+        result = eval(expression)
+        return f"Result: {result}"
+    except Exception as e:
+        return f"Error: {str(e)}"
+`;
+
+    this.writeFile(`src/${packageName}/tools/__init__.py`, toolsContent);
+
+    // Handlers module
+    const handlersContent = `"""
+Request handlers for the ${this.projectName} MCP server.
+"""
+
+import logging
+from typing import Any, Sequence
+
+from mcp.server import Server
+from mcp.types import (
+    Resource,
+    TextContent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def setup_handlers(server: Server):
+    """Set up additional request handlers."""
+    
+    @server.list_resources()
+    async def handle_list_resources() -> list[Resource]:
+        """List available resources."""
+        return [
+            Resource(
+                uri="info://server",
+                name="Server Information",
+                description="Information about this MCP server",
+                mimeType="text/plain"
+            )
+        ]
+    
+    @server.read_resource()
+    async def handle_read_resource(uri: str) -> str:
+        """Read a specific resource."""
+        if uri == "info://server":
+            return f"""${this.projectName} MCP Server
+
+This is a Model Context Protocol server that provides tools and resources.
+
+Version: 0.1.0
+Tools available: echo, calculate
+
+Usage:
+- Use the echo tool to repeat text
+- Use the calculate tool for basic math
+"""
+        else:
+            raise ValueError(f"Unknown resource: {uri}")
+`;
+
+    this.writeFile(`src/${packageName}/handlers/__init__.py`, handlersContent);
+
+    // Utils module
+    const utilsContent = `"""
+Utility functions for the ${this.projectName} MCP server.
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def validate_arguments(arguments: Dict[str, Any], required_fields: list[str]) -> bool:
+    """Validate that all required fields are present in arguments."""
+    return all(field in arguments for field in required_fields)
+
+
+def safe_json_loads(data: str) -> Dict[str, Any]:
+    """Safely load JSON data with error handling."""
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError as e:
+        logger.error(f"JSON decode error: {e}")
+        return {}
+
+
+def format_error(error: Exception) -> str:
+    """Format an error for user-friendly display."""
+    return f"Error: {type(error).__name__}: {str(error)}"
+
+
+class ConfigManager:
+    """Manage configuration for the MCP server."""
+    
+    def __init__(self):
+        self._config = {}
+    
+    def load_config(self, config_path: str = "config.json"):
+        """Load configuration from file."""
+        try:
+            with open(config_path, 'r') as f:
+                self._config = json.load(f)
+        except FileNotFoundError:
+            logger.warning(f"Config file {config_path} not found, using defaults")
+        except json.JSONDecodeError as e:
+            logger.error(f"Error parsing config file: {e}")
+    
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get configuration value."""
+        return self._config.get(key, default)
+    
+    def set(self, key: str, value: Any):
+        """Set configuration value."""
+        self._config[key] = value
+`;
+
+    this.writeFile(`src/${packageName}/utils/__init__.py`, utilsContent);
+
+    // Test files
+    const testServerContent = `"""
+Tests for the MCP server.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from ${packageName}.server import ${this.getProjectNames().pascal}Server
+
+
+@pytest.fixture
+def server():
+    """Create a test server instance."""
+    return ${this.getProjectNames().pascal}Server()
+
+
+def test_server_initialization(server):
+    """Test server initializes correctly."""
+    assert server.server is not None
+    assert server.server.name == "${this.getProjectNames().kebab}"
+
+
+@pytest.mark.asyncio
+async def test_list_tools(server):
+    """Test listing available tools."""
+    # This would need to be implemented based on your actual server setup
+    pass
+
+
+@pytest.mark.asyncio
+async def test_call_tool(server):
+    """Test calling a tool."""
+    # This would need to be implemented based on your actual tools
+    pass
+`;
+
+    this.writeFile(`tests/test_server.py`, testServerContent);
+
+    const testToolsContent = `"""
+Tests for MCP tools.
+"""
+
+import pytest
+
+from ${packageName}.tools import echo_tool, calculate_tool, execute_tool
+
+
+def test_echo_tool():
+    """Test echo tool functionality."""
+    result = echo_tool({"text": "Hello, World!"})
+    assert result == "Echo: Hello, World!"
+
+
+def test_calculate_tool():
+    """Test calculate tool functionality."""
+    result = calculate_tool({"expression": "2 + 2"})
+    assert result == "Result: 4"
+    
+    result = calculate_tool({"expression": "10 * 5"})
+    assert result == "Result: 50"
+
+
+def test_calculate_tool_error():
+    """Test calculate tool error handling."""
+    result = calculate_tool({"expression": "invalid"})
+    assert "Error:" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_tool():
+    """Test tool execution."""
+    result = await execute_tool("echo", {"text": "test"})
+    assert result == "Echo: test"
+    
+    with pytest.raises(ValueError):
+        await execute_tool("nonexistent", {})
+`;
+
+    this.writeFile(`tests/tools/test_tools.py`, testToolsContent);
+  }
+
+  createEssentialFiles() {
+    // README
+    const readme = `# ${this.projectName}
+
+A Model Context Protocol (MCP) server that provides AI tools and integrations.
+
+## Overview
+
+This MCP server enables AI assistants to interact with ${this.projectName} through a standardized protocol. It provides tools for various operations and can be integrated with MCP-compatible AI clients.
+
+## Features
+
+- **Echo Tool**: Simple text echoing for testing
+- **Calculate Tool**: Basic arithmetic calculations
+- **Extensible Architecture**: Easy to add new tools and resources
+
+## Installation
+
+### Using Poetry (Recommended)
+
+\`\`\`bash
+poetry install
+\`\`\`
+
+### Using pip
+
+\`\`\`bash
+pip install -r requirements.txt
+\`\`\`
+
+## Usage
+
+### Running the Server
+
+\`\`\`bash
+# With Poetry
+poetry run ${this.getProjectNames().kebab}
+
+# With pip
+python -m ${this.getProjectNames().snake}.server
+\`\`\`
+
+### Configuration
+
+Create a \`config.json\` file in the project root:
+
+\`\`\`json
+{
+  "debug": false,
+  "log_level": "INFO"
+}
+\`\`\`
+
+### Integration with AI Clients
+
+Add this server to your MCP client configuration:
+
+\`\`\`json
+{
+  "mcpServers": {
+    "${this.getProjectNames().kebab}": {
+      "command": "python",
+      "args": ["-m", "${this.getProjectNames().snake}.server"]
+    }
+  }
+}
+\`\`\`
+
+## Development
+
+### Running Tests
+
+\`\`\`bash
+# With Poetry
+poetry run pytest
+
+# With pip
+pytest
+\`\`\`
+
+### Code Formatting
+
+\`\`\`bash
+# Format code
+poetry run black src/ tests/
+
+# Sort imports
+poetry run isort src/ tests/
+
+# Type checking
+poetry run mypy src/
+\`\`\`
+
+### Adding New Tools
+
+1. Create a new tool function in \`src/${this.getProjectNames().snake}/tools/\`
+2. Add the tool definition to \`AVAILABLE_TOOLS\` list
+3. Update the \`execute_tool\` function to handle the new tool
+4. Add tests for the new tool
+
+Example:
+
+\`\`\`python
+# In tools/__init__.py
+def my_new_tool(arguments: Dict[str, Any]) -> str:
+    """Implementation of my new tool."""
+    return "Tool result"
+
+# Add to AVAILABLE_TOOLS
+Tool(
+    name="my_new_tool",
+    description="Description of what the tool does",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "param": {"type": "string", "description": "Parameter description"}
+        },
+        "required": ["param"]
+    }
+)
+\`\`\`
+
+## Project Structure
+
+\`\`\`
+src/${this.getProjectNames().snake}/
+├── __init__.py          # Package initialization
+├── server.py            # Main MCP server
+├── tools/               # Tool implementations
+│   └── __init__.py
+├── handlers/            # Request handlers
+│   └── __init__.py
+└── utils/               # Utility functions
+    └── __init__.py
+tests/                   # Test files
+docs/                    # Documentation
+examples/                # Usage examples
+\`\`\`
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests for new functionality
+5. Run the test suite
+6. Submit a pull request
+
+## License
+
+This project is licensed under the MIT License. See LICENSE file for details.
+
+## Learn More
+
+- [MCP Specification](https://spec.modelcontextprotocol.io/)
+- [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)
+`;
+
+    this.writeFile('README.md', readme);
+
+    // License file
+    const license = `MIT License
+
+Copyright (c) ${new Date().getFullYear()} ${this.projectName}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+
+    this.writeFile('LICENSE', license);
+
+    // Configuration files
+    const pytestConfig = `[tool:pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = 
+    --verbose
+    --tb=short
+    -ra
+asyncio_mode = auto
+`;
+
+    this.writeFile('pytest.ini', pytestConfig);
+
+    // Example configuration
+    const configExample = `{
+  "debug": false,
+  "log_level": "INFO",
+  "max_retries": 3,
+  "timeout": 30
+}
+`;
+
+    this.writeFile('config.example.json', configExample);
+
+    // Example usage
+    const exampleUsage = `#!/usr/bin/env python3
+"""
+Example usage of the ${this.projectName} MCP server.
+"""
+
+import asyncio
+import json
+from ${this.getProjectNames().snake}.server import ${this.getProjectNames().pascal}Server
+
+
+async def example_usage():
+    """Demonstrate server usage."""
+    server = ${this.getProjectNames().pascal}Server()
+    
+    # This is just an example - actual MCP communication
+    # happens through stdio with the MCP client
+    print("${this.projectName} MCP Server Example")
+    print("In real usage, this server communicates via stdio with MCP clients")
+    print("Run: python -m ${this.getProjectNames().snake}.server")
+
+
+if __name__ == "__main__":
+    asyncio.run(example_usage())
+`;
+
+    this.writeFile('examples/usage_example.py', exampleUsage);
+
+    // Development requirements
+    const devRequirements = `# Development dependencies
+pytest>=7.4.0
+pytest-asyncio>=0.21.0
+black>=23.0.0
+isort>=5.12.0
+flake8>=6.0.0
+mypy>=1.5.0
+pre-commit>=3.4.0
+
+# Documentation
+sphinx>=7.0.0
+sphinx-rtd-theme>=1.3.0
+`;
+
+    this.writeFile('requirements-dev.txt', devRequirements);
+  }
+
+  supportsDependencyInstallation() {
+    return true;
+  }
+
+  async installDependencies() {
+    try {
+      process.chdir(this.targetDirectory);
+      
+      if (this.usePoetry) {
+        execSync('poetry install', { stdio: 'inherit' });
+      } else {
+        execSync('pip install -r requirements.txt', { stdio: 'inherit' });
+      }
+    } catch (error) {
+      this.log('Failed to install dependencies: ' + error.message, 'warning');
+    }
+  }
+
+  getNextSteps() {
+    const steps = [];
+    
+    if (this.usePoetry) {
+      steps.push('poetry install');
+      steps.push('poetry run python -m ' + this.getProjectNames().snake + '.server');
+    } else {
+      steps.push('pip install -r requirements.txt');
+      steps.push('python -m ' + this.getProjectNames().snake + '.server');
+    }
+    
+    steps.push('Configure your MCP client to use this server');
+    
+    return steps;
+  }
+
+  getDefaultGitignore() {
+    return `# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Poetry
+poetry.lock
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Project specific
+config.json
+*.log
+`;
+  }
+}

--- a/src/scaffolders/react-native-scaffolder.js
+++ b/src/scaffolders/react-native-scaffolder.js
@@ -1,0 +1,810 @@
+/**
+ * React Native Scaffolder
+ * 
+ * Creates a React Native project structure with Expo or bare React Native setup.
+ */
+
+import { BaseScaffolder } from './base-scaffolder.js';
+import { execSync } from 'child_process';
+
+export class ReactNativeScaffolder extends BaseScaffolder {
+  constructor(options) {
+    super(options);
+    this.useExpo = options.expo !== false;
+    this.useTypeScript = options.typescript !== false;
+    this.template = options.template || 'tabs';
+  }
+
+  async scaffold() {
+    this.createPackageJson();
+    
+    if (this.useTypeScript) {
+      this.createTypeScriptConfig();
+    }
+    
+    if (this.architecture?.structure) {
+      this.createStructureFromArchitecture();
+    } else {
+      this.createDefaultStructure();
+    }
+    
+    this.createEssentialFiles();
+    this.createExpoConfig();
+  }
+
+  createDefaultStructure() {
+    const dirs = [
+      'src',
+      'src/components',
+      'src/screens',
+      'src/navigation',
+      'src/services',
+      'src/utils',
+      'src/hooks',
+      'src/types',
+      'src/constants',
+      'assets',
+      'assets/images',
+      'assets/fonts',
+      'assets/icons'
+    ];
+
+    dirs.forEach(dir => this.createDirectory(dir));
+    this.createSourceFiles();
+  }
+
+  createPackageJson() {
+    const packageJson = {
+      name: this.getProjectNames().kebab,
+      version: "1.0.0",
+      main: this.useExpo ? "node_modules/expo/AppEntry.js" : "index.js",
+      scripts: {
+        start: this.useExpo ? "expo start" : "react-native start",
+        android: this.useExpo ? "expo start --android" : "react-native run-android",
+        ios: this.useExpo ? "expo start --ios" : "react-native run-ios",
+        web: this.useExpo ? "expo start --web" : undefined,
+        ...(this.useExpo && {
+          "build:android": "expo build:android",
+          "build:ios": "expo build:ios"
+        }),
+        ...(this.useTypeScript && {
+          "type-check": "tsc --noEmit"
+        })
+      },
+      dependencies: {
+        react: "18.2.0",
+        "react-native": "0.72.6",
+        ...(this.useExpo && {
+          expo: "~49.0.15",
+          "@expo/vector-icons": "^13.0.0",
+          "expo-font": "~11.4.0",
+          "expo-linking": "~5.0.2",
+          "expo-router": "^2.0.0",
+          "expo-splash-screen": "~0.20.5",
+          "expo-status-bar": "~1.6.0",
+          "expo-system-ui": "~2.4.0"
+        }),
+        "@react-navigation/native": "^6.1.9",
+        "@react-navigation/native-stack": "^6.9.17",
+        "@react-navigation/bottom-tabs": "^6.5.11",
+        "react-native-safe-area-context": "4.6.3",
+        "react-native-screens": "~3.22.0"
+      },
+      devDependencies: {
+        "@babel/core": "^7.20.0",
+        ...(this.useTypeScript && {
+          typescript: "^5.1.3",
+          "@types/react": "~18.2.14",
+          "@types/react-native": "^0.72.2"
+        })
+      },
+      private: true
+    };
+
+    this.writeFile('package.json', JSON.stringify(packageJson, null, 2));
+  }
+
+  createTypeScriptConfig() {
+    const tsConfig = {
+      extends: "@expo/tsconfig/tsconfig.base",
+      compilerOptions: {
+        strict: true,
+        baseUrl: ".",
+        paths: {
+          "@/*": ["./src/*"]
+        }
+      },
+      include: [
+        "**/*.ts",
+        "**/*.tsx",
+        ".expo/types/**/*.ts",
+        "expo-env.d.ts"
+      ]
+    };
+
+    this.writeFile('tsconfig.json', JSON.stringify(tsConfig, null, 2));
+  }
+
+  createExpoConfig() {
+    if (!this.useExpo) return;
+
+    const appConfig = `import { ExpoConfig, ConfigContext } from 'expo/config';
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: '${this.projectName}',
+  slug: '${this.getProjectNames().kebab}',
+  version: '1.0.0',
+  orientation: 'portrait',
+  icon: './assets/images/icon.png',
+  scheme: '${this.getProjectNames().kebab}',
+  userInterfaceStyle: 'automatic',
+  splash: {
+    image: './assets/images/splash.png',
+    resizeMode: 'contain',
+    backgroundColor: '#ffffff'
+  },
+  assetBundlePatterns: [
+    '**/*'
+  ],
+  ios: {
+    supportsTablet: true,
+    bundleIdentifier: 'com.${this.getProjectNames().kebab.replace(/-/g, '')}.app'
+  },
+  android: {
+    adaptiveIcon: {
+      foregroundImage: './assets/images/adaptive-icon.png',
+      backgroundColor: '#ffffff'
+    },
+    package: 'com.${this.getProjectNames().kebab.replace(/-/g, '')}.app'
+  },
+  web: {
+    bundler: 'metro',
+    output: 'static',
+    favicon: './assets/images/favicon.png'
+  },
+  plugins: [
+    'expo-router',
+    [
+      'expo-splash-screen',
+      {
+        image: './assets/images/splash.png',
+        imageWidth: 200,
+        resizeMode: 'contain',
+        backgroundColor: '#ffffff'
+      }
+    ]
+  ],
+  experiments: {
+    typedRoutes: true
+  }
+});
+`;
+
+    this.writeFile(`app.config.${this.useTypeScript ? 'ts' : 'js'}`, appConfig);
+  }
+
+  createSourceFiles() {
+    const fileExt = this.useTypeScript ? 'tsx' : 'jsx';
+    
+    if (this.useExpo) {
+      this.createExpoRouterFiles(fileExt);
+    } else {
+      this.createReactNavigationFiles(fileExt);
+    }
+    
+    this.createComponentFiles(fileExt);
+  }
+
+  createExpoRouterFiles(fileExt) {
+    // App entry point for Expo Router
+    const layoutContent = `import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { useFonts } from 'expo-font';
+import { Stack } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
+import { useEffect } from 'react';
+import { useColorScheme } from 'react-native';
+
+export {
+  ErrorBoundary,
+} from 'expo-router';
+
+export const unstable_settings = {
+  initialRouteName: '(tabs)',
+};
+
+SplashScreen.preventAutoHideAsync();
+
+export default function RootLayout() {
+  const [loaded, error] = useFonts({
+    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
+    ...FontAwesome.font,
+  });
+
+  useEffect(() => {
+    if (error) throw error;
+  }, [error]);
+
+  useEffect(() => {
+    if (loaded) {
+      SplashScreen.hideAsync();
+    }
+  }, [loaded]);
+
+  if (!loaded) {
+    return null;
+  }
+
+  return <RootLayoutNav />;
+}
+
+function RootLayoutNav() {
+  const colorScheme = useColorScheme();
+
+  return (
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      </Stack>
+    </ThemeProvider>
+  );
+}
+`;
+
+    this.writeFile(`app/_layout.${fileExt}`, layoutContent);
+
+    // Tab layout
+    const tabLayoutContent = `import React from 'react';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { Link, Tabs } from 'expo-router';
+import { Pressable, useColorScheme } from 'react-native';
+
+import Colors from '../../src/constants/Colors';
+
+function TabBarIcon(props${this.useTypeScript ? ': { name: React.ComponentProps<typeof FontAwesome>[\'name\']; color: string }' : ''}) {
+  return <FontAwesome size={28} style={{ marginBottom: -3 }} {...props} />;
+}
+
+export default function TabLayout() {
+  const colorScheme = useColorScheme();
+
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+      }}>
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ color }) => <TabBarIcon name="home" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color }) => <TabBarIcon name="cog" color={color} />,
+        }}
+      />
+    </Tabs>
+  );
+}
+`;
+
+    this.writeFile(`app/(tabs)/_layout.${fileExt}`, tabLayoutContent);
+
+    // Home screen
+    const homeScreenContent = `import { StyleSheet, ScrollView } from 'react-native';
+import { Text, View } from '../../src/components/Themed';
+
+export default function HomeScreen() {
+  return (
+    <ScrollView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Welcome to ${this.projectName}</Text>
+        <Text style={styles.subtitle}>Generated with InitRepo CLI</Text>
+        
+        <View style={styles.separator} />
+        
+        <Text style={styles.description}>
+          This is a React Native app built with Expo Router. 
+          You can start building your amazing mobile app here!
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    opacity: 0.7,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  separator: {
+    marginVertical: 30,
+    height: 1,
+    width: '80%',
+    backgroundColor: '#eee',
+  },
+});
+`;
+
+    this.writeFile(`app/(tabs)/index.${fileExt}`, homeScreenContent);
+
+    // Settings screen
+    const settingsScreenContent = `import { StyleSheet, ScrollView } from 'react-native';
+import { Text, View } from '../../src/components/Themed';
+
+export default function SettingsScreen() {
+  return (
+    <ScrollView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Settings</Text>
+        <Text style={styles.description}>
+          Configure your app settings here.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  description: {
+    fontSize: 16,
+    lineHeight: 24,
+  },
+});
+`;
+
+    this.writeFile(`app/(tabs)/settings.${fileExt}`, settingsScreenContent);
+  }
+
+  createReactNavigationFiles(fileExt) {
+    // App.js for bare React Native
+    const appContent = `import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import HomeScreen from './src/screens/HomeScreen';
+import SettingsScreen from './src/screens/SettingsScreen';
+
+const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator();
+
+function TabNavigator() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
+    </Tab.Navigator>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen 
+          name="Main" 
+          component={TabNavigator} 
+          options={{ headerShown: false }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+`;
+
+    this.writeFile(`App.${fileExt}`, appContent);
+
+    // Home screen
+    const homeScreenContent = `import React from 'react';
+import { StyleSheet, Text, View, ScrollView } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <ScrollView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Welcome to ${this.projectName}</Text>
+        <Text style={styles.subtitle}>Generated with InitRepo CLI</Text>
+        <Text style={styles.description}>
+          This is a React Native app. You can start building your amazing mobile app here!
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    lineHeight: 24,
+    color: '#333',
+  },
+});
+`;
+
+    this.writeFile(`src/screens/HomeScreen.${fileExt}`, homeScreenContent);
+
+    // Settings screen
+    const settingsScreenContent = `import React from 'react';
+import { StyleSheet, Text, View, ScrollView } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <ScrollView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Settings</Text>
+        <Text style={styles.description}>
+          Configure your app settings here.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  description: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#333',
+  },
+});
+`;
+
+    this.writeFile(`src/screens/SettingsScreen.${fileExt}`, settingsScreenContent);
+  }
+
+  createComponentFiles(fileExt) {
+    // Themed components for Expo
+    if (this.useExpo) {
+      const themedContent = `import { Text as DefaultText, View as DefaultView, useColorScheme } from 'react-native';
+import Colors from '../constants/Colors';
+
+${this.useTypeScript ? `type ThemeProps = {
+  lightColor?: string;
+  darkColor?: string;
+};
+
+export type TextProps = ThemeProps & DefaultText['props'];
+export type ViewProps = ThemeProps & DefaultView['props'];
+
+export function useThemeColor(
+  props: { light?: string; dark?: string },
+  colorName: keyof typeof Colors.light & keyof typeof Colors.dark
+) {
+  const theme = useColorScheme() ?? 'light';
+  const colorFromProps = props[theme];
+
+  if (colorFromProps) {
+    return colorFromProps;
+  } else {
+    return Colors[theme][colorName];
+  }
+}` : ''}
+
+export function Text(props${this.useTypeScript ? ': TextProps' : ''}) {
+  const { style, lightColor, darkColor, ...otherProps } = props;
+  const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
+
+  return <DefaultText style={[{ color }, style]} {...otherProps} />;
+}
+
+export function View(props${this.useTypeScript ? ': ViewProps' : ''}) {
+  const { style, lightColor, darkColor, ...otherProps } = props;
+  const backgroundColor = useThemeColor({ light: lightColor, dark: darkColor }, 'background');
+
+  return <DefaultView style={[{ backgroundColor }, style]} {...otherProps} />;
+}
+`;
+
+      this.writeFile(`src/components/Themed.${fileExt}`, themedContent);
+
+      // Colors constants
+      const colorsContent = `const tintColorLight = '#2f95dc';
+const tintColorDark = '#fff';
+
+export default {
+  light: {
+    text: '#000',
+    background: '#fff',
+    tint: tintColorLight,
+    tabIconDefault: '#ccc',
+    tabIconSelected: tintColorLight,
+  },
+  dark: {
+    text: '#fff',
+    background: '#000',
+    tint: tintColorDark,
+    tabIconDefault: '#ccc',
+    tabIconSelected: tintColorDark,
+  },
+};
+`;
+
+      this.writeFile(`src/constants/Colors.${this.useTypeScript ? 'ts' : 'js'}`, colorsContent);
+    }
+  }
+
+  createEssentialFiles() {
+    // README
+    const readme = `# ${this.projectName}
+
+A React Native mobile app generated with InitRepo CLI.
+
+## Tech Stack
+
+- [React Native](https://reactnative.dev/) - Mobile framework
+${this.useExpo ? '- [Expo](https://expo.dev/) - Development platform\n- [Expo Router](https://expo.github.io/router/) - File-based routing\n' : ''}${this.useTypeScript ? '- [TypeScript](https://www.typescriptlang.org/) - Type safety\n' : ''}- [React Navigation](https://reactnavigation.org/) - Navigation library
+
+## Getting Started
+
+1. Install dependencies:
+   \`\`\`bash
+   npm install
+   \`\`\`
+
+2. Start the development server:
+   \`\`\`bash
+   ${this.useExpo ? 'npx expo start' : 'npm start'}
+   \`\`\`
+
+3. Run on your device or emulator:
+   - **iOS**: ${this.useExpo ? 'Press \`i\` in the terminal or scan QR code with Camera app' : '\`npm run ios\`'}
+   - **Android**: ${this.useExpo ? 'Press \`a\` in the terminal or scan QR code with Expo Go app' : '\`npm run android\`'}
+
+## Development
+
+${this.useExpo ? `### Using Expo
+- Download the Expo Go app on your phone
+- Scan the QR code from the terminal
+- Your app will reload when you save changes
+
+### Building for Production
+\`\`\`bash
+npx expo build:android
+npx expo build:ios
+\`\`\`
+` : `### Running on Simulators
+Make sure you have Android Studio (for Android) or Xcode (for iOS) installed.
+
+\`\`\`bash
+# Android
+npm run android
+
+# iOS (macOS only)
+npm run ios
+\`\`\`
+`}
+
+## Project Structure
+
+${this.useExpo ? `- \`app/\` - App Router pages and layouts
+- \`src/components/\` - Reusable React Native components
+- \`src/constants/\` - App constants and themes
+- \`assets/\` - Images, fonts, and other static assets` : `- \`src/screens/\` - App screens
+- \`src/components/\` - Reusable React Native components
+- \`src/navigation/\` - Navigation configuration
+- \`src/services/\` - API and external services`}
+
+## Learn More
+
+- [React Native Documentation](https://reactnative.dev/docs/getting-started)
+${this.useExpo ? '- [Expo Documentation](https://docs.expo.dev/)\n- [Expo Router Documentation](https://expo.github.io/router/)' : '- [React Navigation Documentation](https://reactnavigation.org/docs/getting-started)'}
+`;
+
+    this.writeFile('README.md', readme);
+
+    // Babel config
+    const babelConfig = `module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};
+`;
+
+    this.writeFile('babel.config.js', babelConfig);
+
+    // Metro config for Expo
+    if (this.useExpo) {
+      const metroConfig = `const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = config;
+`;
+
+      this.writeFile('metro.config.js', metroConfig);
+    }
+
+    // Index.js for bare React Native
+    if (!this.useExpo) {
+      const indexContent = `import { AppRegistry } from 'react-native';
+import App from './App';
+import { name as appName } from './package.json';
+
+AppRegistry.registerComponent(appName, () => App);
+`;
+
+      this.writeFile('index.js', indexContent);
+    }
+  }
+
+  supportsDependencyInstallation() {
+    return true;
+  }
+
+  async installDependencies() {
+    try {
+      process.chdir(this.targetDirectory);
+      execSync('npm install', { stdio: 'inherit' });
+    } catch (error) {
+      this.log('Failed to install dependencies: ' + error.message, 'warning');
+    }
+  }
+
+  getNextSteps() {
+    const steps = [];
+    
+    if (this.useExpo) {
+      steps.push('npx expo start');
+      steps.push('Download Expo Go app on your phone');
+      steps.push('Scan the QR code to run your app');
+    } else {
+      steps.push('npm start');
+      steps.push('npm run android (or npm run ios)');
+    }
+    
+    return steps;
+  }
+
+  getDefaultGitignore() {
+    return `# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+.env.test
+
+# Generated by 'expo optimize'
+.expo-optimized/
+
+# Expo
+.expo/
+dist/
+web-build/
+
+# Native
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
+.DS_Store
+*.pem
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo
+`;
+  }
+}

--- a/src/scaffolders/react-scaffolder.js
+++ b/src/scaffolders/react-scaffolder.js
@@ -1,0 +1,590 @@
+/**
+ * React Scaffolder
+ * 
+ * Creates a React project structure with Vite, TypeScript, and modern tooling.
+ */
+
+import { BaseScaffolder } from './base-scaffolder.js';
+import { execSync } from 'child_process';
+
+export class ReactScaffolder extends BaseScaffolder {
+  constructor(options) {
+    super(options);
+    this.useTypeScript = options.typescript !== false;
+    this.useTailwind = options.tailwind !== false;
+    this.bundler = options.bundler || 'vite';
+  }
+
+  async scaffold() {
+    this.createPackageJson();
+    this.createViteConfig();
+    
+    if (this.useTypeScript) {
+      this.createTypeScriptConfig();
+    }
+    
+    if (this.useTailwind) {
+      this.createTailwindConfig();
+    }
+    
+    if (this.architecture?.structure) {
+      this.createStructureFromArchitecture();
+    } else {
+      this.createDefaultStructure();
+    }
+    
+    this.createEssentialFiles();
+  }
+
+  createDefaultStructure() {
+    const dirs = [
+      'src',
+      'src/components',
+      'src/components/ui',
+      'src/hooks',
+      'src/utils',
+      'src/lib',
+      'src/services',
+      'src/types',
+      'src/assets',
+      'public'
+    ];
+
+    dirs.forEach(dir => this.createDirectory(dir));
+    this.createSourceFiles();
+  }
+
+  createPackageJson() {
+    const packageJson = {
+      name: this.getProjectNames().kebab,
+      private: true,
+      version: "0.0.0",
+      type: "module",
+      scripts: {
+        dev: "vite",
+        build: this.useTypeScript ? "tsc && vite build" : "vite build",
+        lint: "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+        preview: "vite preview",
+        ...(this.useTypeScript && { "type-check": "tsc --noEmit" })
+      },
+      dependencies: {
+        react: "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.18.0"
+      },
+      devDependencies: {
+        "@types/react": "^18.2.37",
+        "@types/react-dom": "^18.2.15",
+        "@vitejs/plugin-react": "^4.1.1",
+        vite: "^5.0.0",
+        ...(this.useTypeScript && {
+          typescript: "^5.2.2"
+        }),
+        ...(this.useTailwind && {
+          tailwindcss: "^3.3.5",
+          autoprefixer: "^10.4.16",
+          postcss: "^8.4.31"
+        }),
+        eslint: "^8.53.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-refresh": "^0.4.4",
+        ...(this.useTypeScript && {
+          "@typescript-eslint/eslint-plugin": "^6.10.0",
+          "@typescript-eslint/parser": "^6.10.0"
+        })
+      }
+    };
+
+    this.writeFile('package.json', JSON.stringify(packageJson, null, 2));
+  }
+
+  createViteConfig() {
+    const config = `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': '/src',
+    },
+  },
+})
+`;
+    this.writeFile('vite.config.js', config);
+  }
+
+  createTypeScriptConfig() {
+    const tsConfig = {
+      compilerOptions: {
+        target: "ES2020",
+        useDefineForClassFields: true,
+        lib: ["ES2020", "DOM", "DOM.Iterable"],
+        module: "ESNext",
+        skipLibCheck: true,
+        moduleResolution: "bundler",
+        allowImportingTsExtensions: true,
+        resolveJsonModule: true,
+        isolatedModules: true,
+        noEmit: true,
+        jsx: "react-jsx",
+        strict: true,
+        noUnusedLocals: true,
+        noUnusedParameters: true,
+        noFallthroughCasesInSwitch: true,
+        baseUrl: ".",
+        paths: {
+          "@/*": ["./src/*"]
+        }
+      },
+      include: ["src"],
+      references: [{ path: "./tsconfig.node.json" }]
+    };
+
+    this.writeFile('tsconfig.json', JSON.stringify(tsConfig, null, 2));
+
+    const nodeConfig = {
+      compilerOptions: {
+        composite: true,
+        skipLibCheck: true,
+        module: "ESNext",
+        moduleResolution: "bundler",
+        allowSyntheticDefaultImports: true
+      },
+      include: ["vite.config.js"]
+    };
+
+    this.writeFile('tsconfig.node.json', JSON.stringify(nodeConfig, null, 2));
+  }
+
+  createTailwindConfig() {
+    const tailwindConfig = `/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+`;
+
+    this.writeFile('tailwind.config.js', tailwindConfig);
+
+    const postcssConfig = `export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}
+`;
+
+    this.writeFile('postcss.config.js', postcssConfig);
+  }
+
+  createSourceFiles() {
+    const fileExt = this.useTypeScript ? 'tsx' : 'jsx';
+    
+    // Main App component
+    const appContent = `import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import Home from './components/Home'
+import About from './components/About'
+import Navigation from './components/Navigation'
+${this.useTailwind ? "import './App.css'" : "import './App.css'"}
+
+function App() {
+  return (
+    <Router>
+      <div className="${this.useTailwind ? 'min-h-screen bg-gray-50' : 'app'}">
+        <Navigation />
+        <main className="${this.useTailwind ? 'container mx-auto px-4 py-8' : 'main-content'}">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/about" element={<About />} />
+          </Routes>
+        </main>
+      </div>
+    </Router>
+  )
+}
+
+export default App
+`;
+
+    this.writeFile(`src/App.${fileExt}`, appContent);
+
+    // Home component
+    const homeContent = `function Home() {
+  return (
+    <div className="${this.useTailwind ? 'text-center' : 'home'}">
+      <h1 className="${this.useTailwind ? 'text-4xl font-bold text-gray-900 mb-4' : 'title'}">
+        Welcome to ${this.projectName}
+      </h1>
+      <p className="${this.useTailwind ? 'text-lg text-gray-600' : 'description'}">
+        Generated with InitRepo CLI
+      </p>
+      <div className="${this.useTailwind ? 'mt-8' : 'actions'}">
+        <button className="${this.useTailwind ? 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' : 'button'}">
+          Get Started
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default Home
+`;
+
+    this.writeFile(`src/components/Home.${fileExt}`, homeContent);
+
+    // About component
+    const aboutContent = `function About() {
+  return (
+    <div className="${this.useTailwind ? 'max-w-2xl mx-auto' : 'about'}">
+      <h1 className="${this.useTailwind ? 'text-3xl font-bold text-gray-900 mb-6' : 'title'}">About</h1>
+      <p className="${this.useTailwind ? 'text-gray-600 mb-4' : 'text'}">
+        This is a React application scaffolded with InitRepo CLI.
+      </p>
+      <p className="${this.useTailwind ? 'text-gray-600' : 'text'}">
+        It includes modern tooling and best practices for React development.
+      </p>
+    </div>
+  )
+}
+
+export default About
+`;
+
+    this.writeFile(`src/components/About.${fileExt}`, aboutContent);
+
+    // Navigation component
+    const navContent = `import { Link, useLocation } from 'react-router-dom'
+
+function Navigation() {
+  const location = useLocation()
+
+  const isActive = (path${this.useTypeScript ? ': string' : ''}) => location.pathname === path
+
+  return (
+    <nav className="${this.useTailwind ? 'bg-white shadow-sm' : 'nav'}">
+      <div className="${this.useTailwind ? 'container mx-auto px-4' : 'nav-container'}">
+        <div className="${this.useTailwind ? 'flex justify-between items-center h-16' : 'nav-content'}">
+          <Link 
+            to="/" 
+            className="${this.useTailwind ? 'text-xl font-bold text-gray-900' : 'logo'}"
+          >
+            ${this.projectName}
+          </Link>
+          <div className="${this.useTailwind ? 'flex space-x-4' : 'nav-links'}">
+            <Link 
+              to="/" 
+              className={\`${this.useTailwind ? 'px-3 py-2 rounded-md text-sm font-medium' : 'nav-link'} \${
+                isActive('/') 
+                  ? '${this.useTailwind ? 'bg-gray-900 text-white' : 'active'}' 
+                  : '${this.useTailwind ? 'text-gray-600 hover:text-gray-900' : ''}'
+              }\`}
+            >
+              Home
+            </Link>
+            <Link 
+              to="/about" 
+              className={\`${this.useTailwind ? 'px-3 py-2 rounded-md text-sm font-medium' : 'nav-link'} \${
+                isActive('/about') 
+                  ? '${this.useTailwind ? 'bg-gray-900 text-white' : 'active'}' 
+                  : '${this.useTailwind ? 'text-gray-600 hover:text-gray-900' : ''}'
+              }\`}
+            >
+              About
+            </Link>
+          </div>
+        </div>
+      </div>
+    </nav>
+  )
+}
+
+export default Navigation
+`;
+
+    this.writeFile(`src/components/Navigation.${fileExt}`, navContent);
+
+    // Main entry point
+    const mainContent = `import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.${fileExt}'
+${this.useTailwind ? "import './index.css'" : "import './index.css'"}
+
+ReactDOM.createRoot(document.getElementById('root')${this.useTypeScript ? '!' : ''}).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)
+`;
+
+    this.writeFile(`src/main.${fileExt}`, mainContent);
+  }
+
+  createEssentialFiles() {
+    // index.html
+    const indexHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${this.projectName}</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.${this.useTypeScript ? 'tsx' : 'jsx'}"></script>
+  </body>
+</html>
+`;
+
+    this.writeFile('index.html', indexHtml);
+
+    // Styles
+    if (this.useTailwind) {
+      const indexCss = `@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+
+  color-scheme: light dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+}
+`;
+      this.writeFile('src/index.css', indexCss);
+
+      const appCss = `/* Custom styles for the app */
+`;
+      this.writeFile('src/App.css', appCss);
+    } else {
+      const indexCss = `/* CSS Reset and Base Styles */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  line-height: 1.6;
+  color: #333;
+  background-color: #f5f5f5;
+}
+
+#root {
+  min-height: 100vh;
+}
+`;
+      this.writeFile('src/index.css', indexCss);
+
+      const appCss = `.app {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+}
+
+.main-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.nav {
+  background-color: white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.nav-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.nav-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 64px;
+}
+
+.logo {
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: #333;
+  text-decoration: none;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-link {
+  padding: 0.5rem 1rem;
+  color: #666;
+  text-decoration: none;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s;
+}
+
+.nav-link:hover {
+  background-color: #f3f4f6;
+}
+
+.nav-link.active {
+  background-color: #333;
+  color: white;
+}
+
+.home, .about {
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.title {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+  color: #333;
+}
+
+.description, .text {
+  font-size: 1.125rem;
+  color: #666;
+  margin-bottom: 1rem;
+}
+
+.actions {
+  margin-top: 2rem;
+}
+
+.button {
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.375rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.button:hover {
+  background-color: #2563eb;
+}
+`;
+      this.writeFile('src/App.css', appCss);
+    }
+
+    // README
+    const readme = `# ${this.projectName}
+
+A React application generated with InitRepo CLI.
+
+## Tech Stack
+
+- [React](https://reactjs.org/) - UI library
+- [Vite](https://vitejs.dev/) - Build tool
+- [React Router](https://reactrouter.com/) - Routing
+${this.useTypeScript ? '- [TypeScript](https://www.typescriptlang.org/) - Type safety\n' : ''}${this.useTailwind ? '- [Tailwind CSS](https://tailwindcss.com/) - Styling\n' : ''}
+## Getting Started
+
+1. Install dependencies:
+   \`\`\`bash
+   npm install
+   \`\`\`
+
+2. Start the development server:
+   \`\`\`bash
+   npm run dev
+   \`\`\`
+
+3. Open [http://localhost:5173](http://localhost:5173) to view it in the browser.
+
+## Available Scripts
+
+- \`npm run dev\` - Start development server
+- \`npm run build\` - Build for production
+- \`npm run preview\` - Preview production build
+- \`npm run lint\` - Run ESLint
+
+## Project Structure
+
+- \`src/\` - Source code
+- \`src/components/\` - React components
+- \`src/hooks/\` - Custom React hooks
+- \`src/utils/\` - Utility functions
+- \`public/\` - Static assets
+`;
+
+    this.writeFile('README.md', readme);
+
+    // ESLint config
+    const eslintConfig = `module.exports = {
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    '@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+  },
+}
+`;
+
+    this.writeFile('.eslintrc.cjs', eslintConfig);
+  }
+
+  supportsDependencyInstallation() {
+    return true;
+  }
+
+  async installDependencies() {
+    try {
+      process.chdir(this.targetDirectory);
+      execSync('npm install', { stdio: 'inherit' });
+    } catch (error) {
+      this.log('Failed to install dependencies: ' + error.message, 'warning');
+    }
+  }
+
+  getNextSteps() {
+    return [
+      'npm run dev',
+      'Open http://localhost:5173 in your browser'
+    ];
+  }
+}


### PR DESCRIPTION
- Add scaffold command with support for multiple project types:
  * nextjs: Next.js apps with App Router, TypeScript, Tailwind
  * react: React apps with Vite, TypeScript, React Router
  * react-native: React Native with Expo or bare setup
  * python-mcp: Python MCP server projects
  * python-automation: Python automation frameworks

- Implement architecture file parsing (technical_architecture.md)
- Create base scaffolder class with common functionality
- Add comprehensive project templates with:
  * Package configurations (package.json, pyproject.toml)
  * TypeScript/build configurations
  * Styling setup (Tailwind CSS)
  * Example components and starter code
  * README files and documentation
  * Development scripts and tooling

- Features include:
  * Smart project type detection from architecture files
  * Automatic dependency installation
  * Git repository initialization
  * Complete folder structure creation
  * Production-ready project setup

Usage: initrepo scaffold <type> <name> [options]

🤖 Generated with [Claude Code](https://claude.ai/code)